### PR TITLE
Add traits

### DIFF
--- a/src/main/kotlin/screeps/api/ConstructionSite.kt
+++ b/src/main/kotlin/screeps/api/ConstructionSite.kt
@@ -1,10 +1,6 @@
 package screeps.api
 
-import screeps.api.structures.Owner
-
-external class ConstructionSite : RoomObject {
-    val my: Boolean
-    val owner: Owner
+abstract external class ConstructionSite : RoomObject, Owned, Identifiable {
     val progress: Int
     val progressTotal: Int
     val structureType: BuildableStructureConstant

--- a/src/main/kotlin/screeps/api/Creep.kt
+++ b/src/main/kotlin/screeps/api/Creep.kt
@@ -1,22 +1,17 @@
 package screeps.api
 
-import screeps.api.structures.Owner
 import screeps.api.structures.Structure
 import screeps.api.structures.StructureController
 import screeps.utils.Style
 
 
-external class Creep : RoomObject {
+abstract external class Creep : RoomObject, Owned, Attackable, Container, Identifiable {
     val body: Array<BodyPart>
     val carry: Storage
     val carryCapacity: Int
     val fatigue: Int
-    val hits: Int
-    val hitsMax: Int
     val memory: CreepMemory
-    val my: Boolean
     val name: String
-    val owner: Owner
     val saying: String
     val spawning: Boolean
     val ticksToLive: Int
@@ -50,22 +45,13 @@ external class Creep : RoomObject {
     fun say(message: String, toPublic: Boolean = definedExternally): ScreepsReturnCode
     fun signController(controller: StructureController, text: String): ScreepsReturnCode
     fun suicide(): ScreepsReturnCode
-    fun transfer(target: Creep, resourceType: ResourceConstant, amount: Int = definedExternally): ScreepsReturnCode
-    fun transfer(target: Structure, resourceType: ResourceConstant, amount: Int = definedExternally): ScreepsReturnCode
+    fun transfer(target: Container, resourceType: ResourceConstant, amount: Int = definedExternally): ScreepsReturnCode
     fun upgradeController(controller: StructureController): ScreepsReturnCode
     fun withdraw(
-        structure: Structure,
+        structure: Container,
         resourceType: ResourceConstant,
         amount: Int = definedExternally
     ): ScreepsReturnCode
-
-    fun withdraw(
-        tombstone: Tombstone,
-        resourceType: ResourceConstant,
-        amount: Int = definedExternally
-    ): ScreepsReturnCode
-
-
 }
 
 external interface Storage {

--- a/src/main/kotlin/screeps/api/Flag.kt
+++ b/src/main/kotlin/screeps/api/Flag.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-external class Flag : RoomObject {
+abstract external class Flag : RoomObject {
     val color: ColorConstant
     val memory: FlagMemory
     val name: String

--- a/src/main/kotlin/screeps/api/Game.kt
+++ b/src/main/kotlin/screeps/api/Game.kt
@@ -56,7 +56,7 @@ external object Game {
      * Get an object with the specified unique ID. It may be a game object of any type.
      * Only objects from the rooms which are visible to you can be accessed.
      */
-    fun <T : GameObject> getObjectById(id: String?): T?
+    fun <T : Identifiable> getObjectById(id: String?): T?
 
     /**
      * Send a custom message at your profile email.

--- a/src/main/kotlin/screeps/api/GameObject.kt
+++ b/src/main/kotlin/screeps/api/GameObject.kt
@@ -1,5 +1,0 @@
-package screeps.api
-
-open external class GameObject {
-    val id: String
-}

--- a/src/main/kotlin/screeps/api/Market.kt
+++ b/src/main/kotlin/screeps/api/Market.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-import screeps.api.structures.Owner
+import screeps.api.Owned.Owner
 
 external interface Market {
     val credits: Double

--- a/src/main/kotlin/screeps/api/Mineral.kt
+++ b/src/main/kotlin/screeps/api/Mineral.kt
@@ -1,8 +1,7 @@
 package screeps.api
 
-external class Mineral : RoomObject {
+abstract external class Mineral : RoomObject, Harvestable, Identifiable {
     val density: DensityConstant
     val mineralAmount: Int
     val mineralType: MineralConstant
-    val ticksToRegeneration: Int
 }

--- a/src/main/kotlin/screeps/api/Nuke.kt
+++ b/src/main/kotlin/screeps/api/Nuke.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-external class Nuke : RoomObject {
+abstract external class Nuke : RoomObject {
     val launchRoomName: String
     val timeToLand: Int
 }

--- a/src/main/kotlin/screeps/api/Resource.kt
+++ b/src/main/kotlin/screeps/api/Resource.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-external class Resource : RoomObject {
+abstract external class Resource : RoomObject, Identifiable {
     val amount: Int
     val resourceType: ResourceConstant
 }

--- a/src/main/kotlin/screeps/api/RoomObject.kt
+++ b/src/main/kotlin/screeps/api/RoomObject.kt
@@ -1,6 +1,5 @@
 package screeps.api
 
-open external class RoomObject : GameObject {
-    val pos: RoomPosition
+external interface RoomObject : HasPosition {
     val room: Room
 }

--- a/src/main/kotlin/screeps/api/RoomPosition.kt
+++ b/src/main/kotlin/screeps/api/RoomPosition.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-external class RoomPosition(x: Int, y: Int, roomName: String) {
+external class RoomPosition(x: Int, y: Int, roomName: String) : NavigationTarget {
     val roomName: String
     val x: Int
     val y: Int

--- a/src/main/kotlin/screeps/api/Source.kt
+++ b/src/main/kotlin/screeps/api/Source.kt
@@ -1,9 +1,6 @@
 package screeps.api
 
-
-external class Source : RoomObject {
+abstract external class Source : RoomObject, Harvestable, Identifiable {
     val energy: Int
     val energyCapacity: Int
-    val ticksToRegeneration: Int
-
 }

--- a/src/main/kotlin/screeps/api/Tombstone.kt
+++ b/src/main/kotlin/screeps/api/Tombstone.kt
@@ -1,8 +1,7 @@
 package screeps.api
 
-external class Tombstone : RoomObject {
+abstract external class Tombstone : RoomObject, Decaying, Container, Identifiable {
     val creep: Creep
     val deathTime: Int
     val store: Storage
-    val ticksToDecay: Int
 }

--- a/src/main/kotlin/screeps/api/structures/Structure.kt
+++ b/src/main/kotlin/screeps/api/structures/Structure.kt
@@ -1,43 +1,16 @@
 package screeps.api.structures
 
+import screeps.api.Attackable
+import screeps.api.Identifiable
 import screeps.api.RoomObject
 import screeps.api.ScreepsReturnCode
 import screeps.api.StructureConstant
 
 
-open external class Structure : RoomObject {
-    val hits: Double
-    val hitsMax: Double
+abstract external class Structure : RoomObject, Attackable, Identifiable {
     val structureType: StructureConstant
 
     fun destroy(): ScreepsReturnCode
     fun isActive(): Boolean
     fun notifyWhenAttacked(enabled: Boolean): ScreepsReturnCode
 }
-
-open external class OwnedStructure : Structure {
-    val my: Boolean
-    val owner: Owner
-}
-
-external interface Owner {
-    val username: String
-}
-
-external interface EnergyContainingStructure {
-    val energy: Int
-    val energyCapacity: Int
-}
-
-/**
- * Energy can be used for spawning of creeps.
- */
-external interface EnergyStructure : EnergyContainingStructure
-
-external interface DecayingStructure {
-    val ticksToDecay: Int
-}
-
-
-
-

--- a/src/main/kotlin/screeps/api/structures/StructureContainer.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureContainer.kt
@@ -1,9 +1,10 @@
 package screeps.api.structures
 
+import screeps.api.Container
+import screeps.api.Decaying
 import screeps.api.Storage
 
-external class StructureContainer : Structure {
+abstract external class StructureContainer : Structure, Decaying, Container {
     val store: Storage
     val storeCapacity: Int
-    val ticksToDecay: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureController.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureController.kt
@@ -1,9 +1,10 @@
 package screeps.api.structures
 
+import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
 import kotlin.js.Date
 
-external class StructureController : OwnedStructure {
+abstract external class StructureController : Structure, Owned {
     val level: Int
     val progress: Int
     val progressTotal: Int

--- a/src/main/kotlin/screeps/api/structures/StructureExtension.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureExtension.kt
@@ -1,4 +1,6 @@
 package screeps.api.structures
 
-abstract external class StructureExtension : OwnedStructure,
-    EnergyStructure
+import screeps.api.Owned
+import screeps.api.SpawnEnergyProvider
+
+abstract external class StructureExtension : Structure, Owned, SpawnEnergyProvider

--- a/src/main/kotlin/screeps/api/structures/StructureExtractor.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureExtractor.kt
@@ -1,5 +1,7 @@
 package screeps.api.structures
 
-external class StructureExtractor : OwnedStructure {
+import screeps.api.Owned
+
+abstract external class StructureExtractor : Structure, Owned {
     val cooldown: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureKeeperLair.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureKeeperLair.kt
@@ -1,5 +1,7 @@
 package screeps.api.structures
 
-external class StructureKeeperLair : OwnedStructure {
+import screeps.api.Owned
+
+abstract external class StructureKeeperLair : Structure, Owned {
     val ticksToSpawn: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureLab.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureLab.kt
@@ -1,10 +1,11 @@
 package screeps.api.structures
 
 import screeps.api.Creep
+import screeps.api.EnergyContainer
+import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
 
-abstract external class StructureLab : OwnedStructure,
-    EnergyContainingStructure {
+abstract external class StructureLab : Structure, Owned, EnergyContainer {
     val cooldown: Int
     val mineralAmount: Int
     val mineralType: String

--- a/src/main/kotlin/screeps/api/structures/StructureLink.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureLink.kt
@@ -1,7 +1,9 @@
 package screeps.api.structures
 
-abstract external class StructureLink : OwnedStructure,
-    EnergyContainingStructure {
+import screeps.api.EnergyContainer
+import screeps.api.Owned
+
+abstract external class StructureLink : Structure, Owned, EnergyContainer {
     val cooldown: Int
     fun transferEnergy(target: StructureLink, amount: Int = definedExternally)
 }

--- a/src/main/kotlin/screeps/api/structures/StructureNuker.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureNuker.kt
@@ -1,10 +1,11 @@
 package screeps.api.structures
 
+import screeps.api.EnergyContainer
+import screeps.api.Owned
 import screeps.api.RoomPosition
 import screeps.api.ScreepsReturnCode
 
-abstract external class StructureNuker : OwnedStructure,
-    EnergyContainingStructure {
+abstract external class StructureNuker : Structure, Owned, EnergyContainer {
     val ghodium: Int
     val ghodiumCapacity: Int
     val coolDown: Int

--- a/src/main/kotlin/screeps/api/structures/StructureObserver.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureObserver.kt
@@ -1,11 +1,12 @@
 package screeps.api.structures
 
+import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
 
 /**
  * Provides visibility into a distant room from your script.
  */
-external class StructureObserver : OwnedStructure {
+abstract external class StructureObserver : Structure, Owned {
     /**
      * Provide visibility into a distant room from your script. The target room object will be available on the next tick.
      */

--- a/src/main/kotlin/screeps/api/structures/StructurePortal.kt
+++ b/src/main/kotlin/screeps/api/structures/StructurePortal.kt
@@ -1,5 +1,8 @@
 package screeps.api.structures
 
-abstract external class StructurePortal : Structure, DecayingStructure {
+import screeps.api.Decaying
+
+abstract external class StructurePortal : Structure, Decaying {
     val destination: dynamic
+
 }

--- a/src/main/kotlin/screeps/api/structures/StructurePowerBank.kt
+++ b/src/main/kotlin/screeps/api/structures/StructurePowerBank.kt
@@ -1,6 +1,8 @@
 package screeps.api.structures
 
-abstract external class StructurePowerBank : Structure,
-    DecayingStructure {
+import screeps.api.Container
+import screeps.api.Decaying
+
+abstract external class StructurePowerBank : Structure, Decaying, Container {
     val power: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructurePowerSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructurePowerSpawn.kt
@@ -1,12 +1,13 @@
 package screeps.api.structures
 
+import screeps.api.EnergyContainer
+import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
 
 /**
  * under development!
  */
-abstract external class StructurePowerSpawn : OwnedStructure,
-    EnergyContainingStructure {
+abstract external class StructurePowerSpawn : Structure, Owned, EnergyContainer {
     val power: Int
     val powerCapacity: Int
     fun processPower(): ScreepsReturnCode

--- a/src/main/kotlin/screeps/api/structures/StructureRampart.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureRampart.kt
@@ -1,9 +1,10 @@
 package screeps.api.structures
 
+import screeps.api.Decaying
+import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
 
-external class StructureRampart : OwnedStructure {
+abstract external class StructureRampart : Structure, Owned, Decaying {
     val isPublic: Boolean
-    val ticksToDecay: Int
     fun setPublic(isPublic: Boolean): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/structures/StructureRoad.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureRoad.kt
@@ -1,3 +1,5 @@
 package screeps.api.structures
 
-abstract external class StructureRoad : Structure, DecayingStructure
+import screeps.api.Decaying
+
+abstract external class StructureRoad : Structure, Decaying

--- a/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureSpawn : OwnedStructure, EnergyStructure {
+abstract external class StructureSpawn : Structure, Owned, SpawnEnergyProvider {
     val memory: SpawnMemory
     val name: String
 
@@ -56,7 +56,7 @@ interface SpawnOptions {
 
 open class FullSpawnOptions(
     override val memory: CreepMemory? = null,
-    open val energyContainingStructure: Array<EnergyStructure>? = null,
+    open val energyContainingStructure: Array<SpawnEnergyProvider>? = null,
     open val dryRun: Boolean = false,
     open val directions: Array<DirectionConstant>? = null
 ) : SpawnOptions

--- a/src/main/kotlin/screeps/api/structures/StructureStorage.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureStorage.kt
@@ -1,8 +1,10 @@
 package screeps.api.structures
 
+import screeps.api.Container
+import screeps.api.Owned
 import screeps.api.Storage
 
-external class StructureStorage : OwnedStructure {
+abstract external class StructureStorage : Structure, Owned, Container {
     val store: Storage
     val storeCapacity: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
@@ -1,10 +1,8 @@
 package screeps.api.structures
 
-import screeps.api.ResourceConstant
-import screeps.api.ScreepsReturnCode
-import screeps.api.Storage
+import screeps.api.*
 
-external class StructureTerminal : OwnedStructure {
+abstract external class StructureTerminal : Structure, Owned, Container {
     val cooldown: Int
     val store: Storage
     val storeCapacity: Int

--- a/src/main/kotlin/screeps/api/structures/StructureTower.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureTower.kt
@@ -1,12 +1,12 @@
 package screeps.api.structures
 
 import screeps.api.Creep
+import screeps.api.EnergyContainer
+import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
 
-abstract external class StructureTower : OwnedStructure,
-    EnergyContainingStructure {
+abstract external class StructureTower : Structure, Owned, EnergyContainer {
     fun attack(target: Creep): ScreepsReturnCode
     fun heal(target: Creep): ScreepsReturnCode
     fun repair(target: Structure): ScreepsReturnCode
-
 }

--- a/src/main/kotlin/screeps/api/structures/StructureWall.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureWall.kt
@@ -1,3 +1,3 @@
 package screeps.api.structures
 
-external class StructureWall : Structure
+abstract external class StructureWall : Structure

--- a/src/main/kotlin/screeps/api/traits.kt
+++ b/src/main/kotlin/screeps/api/traits.kt
@@ -1,0 +1,41 @@
+package screeps.api
+
+external interface Identifiable {
+    val id: String
+}
+
+external interface Harvestable {
+    val ticksToRegeneration: Int
+}
+
+external interface Decaying {
+    val ticksToDecay: Int
+}
+
+external interface Owned {
+    val my: Boolean
+    val owner: Owner
+
+    interface Owner {
+        val username: String
+    }
+}
+
+external interface Attackable {
+    val hits: Int
+    val hitsMax: Int
+}
+
+external interface NavigationTarget
+external interface HasPosition : NavigationTarget {
+    val pos: RoomPosition
+}
+
+external interface Container
+
+external interface EnergyContainer : Container {
+    val energy: Int
+    val energyCapacity: Int
+}
+
+external interface SpawnEnergyProvider : EnergyContainer


### PR DESCRIPTION
Adds external interfaces to group classes, primarily for use in function arguments. Allows for something similar to union types.
As a side effect this also makes most classes abstract, to avoid having to override all the properties inherited. This should not be an issue, as we should not directly instantiate game classes.

Also closes #3 