### PR TITLE
add full types for RoomVisual

### DIFF
--- a/src/main/kotlin/screeps/api/Constants.kt
+++ b/src/main/kotlin/screeps/api/Constants.kt
@@ -262,7 +262,8 @@ external val ORDER_SELL: OrderConstant
 external val ORDER_BUY: OrderConstant
 external val SUBSCRIPTION_TOKEN: TradableConstant
 
-// Constants to restrict function arguments
+// Kotlin specific constants - used to indicate a subset of a type
+// E.g. "plain" | "swamp" | "wall" as specified by the API.
 
 external interface TerrainConstant : StringConstant
 external interface LineStyleConstant : StringConstant

--- a/src/main/kotlin/screeps/api/Constants.kt
+++ b/src/main/kotlin/screeps/api/Constants.kt
@@ -263,8 +263,19 @@ external val ORDER_BUY: OrderConstant
 external val SUBSCRIPTION_TOKEN: TradableConstant
 
 // Constants to restrict function arguments
+
 external interface TerrainConstant : StringConstant
+external interface LineStyleConstant : StringConstant
+external interface TextAlignConstant : StringConstant
 
 val TERRAIN_PLAIN: TerrainConstant = "plain".unsafeCast<TerrainConstant>()
 val TERRAIN_SWAMP: TerrainConstant = "swamp".unsafeCast<TerrainConstant>()
 val TERRAIN_WALL: TerrainConstant = "wall".unsafeCast<TerrainConstant>()
+
+val LINE_STYLE_DASHED: LineStyleConstant = "dashed".unsafeCast<LineStyleConstant>()
+val LINE_STYLE_DOTTED: LineStyleConstant = "dotted".unsafeCast<LineStyleConstant>()
+val LINE_STYLE_SOLID: LineStyleConstant = undefined.unsafeCast<LineStyleConstant>()
+
+val TEXT_ALIGN_LEFT: TextAlignConstant = "left".unsafeCast<TextAlignConstant>()
+val TEXT_ALIGN_CENTER: TextAlignConstant = "center".unsafeCast<TextAlignConstant>()
+val TEXT_ALIGN_RIGHT: TextAlignConstant = "right".unsafeCast<TextAlignConstant>()

--- a/src/main/kotlin/screeps/api/Creep.kt
+++ b/src/main/kotlin/screeps/api/Creep.kt
@@ -2,7 +2,6 @@ package screeps.api
 
 import screeps.api.structures.Structure
 import screeps.api.structures.StructureController
-import screeps.utils.Style
 
 
 abstract external class Creep : RoomObject, Owned, Attackable, Container, Identifiable {
@@ -69,7 +68,7 @@ class MoveToOpts(
     val reusePath: Int = 5,
     val serializeMemory: Boolean = true,
     val noPathFinding: Boolean = false,
-    val visualizePathStyle: Style = Style(),
+    val visualizePathStyle: RoomVisual.ShapeStyle,
 
     val ignoreCreeps: Boolean = false,
     val ignoreDestructibleStructures: Boolean = false,

--- a/src/main/kotlin/screeps/api/RoomVisual.kt
+++ b/src/main/kotlin/screeps/api/RoomVisual.kt
@@ -1,20 +1,51 @@
 package screeps.api
 
-external class RoomVisual() {
-    constructor(roomName: String)
-
+external class RoomVisual(roomName: String) {
     val roomName: String
-    fun line(x1: Int, y1: Int, x2: Int, y2: Int, style: dynamic = definedExternally): RoomVisual
-    fun line(start: RoomPosition, end: RoomPosition, style: dynamic = definedExternally): RoomVisual
-    fun line(x: Int, y: Int, style: dynamic = definedExternally): RoomVisual
-    fun line(center: RoomPosition, style: dynamic = definedExternally): RoomVisual
-    fun rect(topLeft_X: Int, topLeft_Y: Int, width: Int, height: Int, style: dynamic = definedExternally): RoomVisual
-    fun rect(topLeftPosition: RoomPosition, width: Int, height: Int, style: dynamic = definedExternally): RoomVisual
-    fun poly(points: Array<RoomPosition>, style: dynamic = definedExternally): RoomVisual
-    fun poly(points: Array<Array<Int>>, style: dynamic = definedExternally): RoomVisual
-    fun text(text: String, x: Int, y: Int, style: dynamic = definedExternally): RoomVisual
-    fun text(text: String, position: RoomPosition, style: dynamic = definedExternally): RoomVisual
+
+    fun line(x1: Int, y1: Int, x2: Int, y2: Int, style: LineStyle = definedExternally): RoomVisual
+    fun line(start: RoomPosition, end: RoomPosition, style: LineStyle = definedExternally): RoomVisual
+    fun line(x: Int, y: Int, style: LineStyle = definedExternally): RoomVisual
+    fun line(pos: RoomPosition, style: LineStyle = definedExternally): RoomVisual
+    fun circle(x: Int, y: Int, style: CircleStyle = definedExternally): RoomVisual
+    fun circle(pos: RoomPosition, style: CircleStyle = definedExternally): RoomVisual
+    fun rect(x: Int, y: Int, width: Int, height: Int, style: ShapeStyle = definedExternally): RoomVisual
+    fun rect(topLeftPosition: RoomPosition, width: Int, height: Int, style: ShapeStyle = definedExternally): RoomVisual
+    fun poly(points: Array<RoomPosition>, style: ShapeStyle = definedExternally): RoomVisual
+    fun poly(points: Array<Array<Int>>, style: ShapeStyle = definedExternally): RoomVisual
+    fun text(text: String, x: Int, y: Int, style: TextStyle = definedExternally): RoomVisual
+    fun text(text: String, position: RoomPosition, style: TextStyle = definedExternally): RoomVisual
     fun clear(): RoomVisual
     fun getSize(): Int
 
+    interface Style {
+        var opacity: Double?
+        var lineStyle: LineStyleConstant?
+    }
+
+    interface LineStyle : Style {
+        var color: String?
+        var width: Double?
+    }
+
+    interface ShapeStyle : Style {
+        var fill: String?
+        var stroke: String?
+        var strokeWidth: Double?
+    }
+
+    interface CircleStyle : ShapeStyle {
+        var radius: Double?
+    }
+
+    interface TextStyle {
+        var color: String?
+        var font: String?
+        var stroke: String?
+        var strokeWidth: Double?
+        var backgroundColor: String?
+        var backgroundPadding: String?
+        var align: TextAlignConstant?
+        var opacity: Double?
+    }
 }

--- a/src/main/kotlin/screeps/utils/Options.kt
+++ b/src/main/kotlin/screeps/utils/Options.kt
@@ -1,73 +1,7 @@
 package screeps.utils
 
 import screeps.api.Game
-import screeps.api.LineStyleConstant
-import screeps.api.RoomVisual
-import screeps.api.TextAlignConstant
 
 fun routeOptions(routeCallback: (roomName: String, fromRoomName: String) -> Double): Game.Map.RouteOptions = jsObject {
     this.routeCallback = routeCallback
-}
-
-// RoomVisual style options
-fun lineStyle(
-    width: Double? = null,
-    color: String? = null,
-    opacity: Double? = null,
-    lineStyle: LineStyleConstant? = null
-): RoomVisual.LineStyle = jsObject {
-    this.width = width
-    this.color = color
-    this.opacity = opacity
-    this.lineStyle = lineStyle
-}
-
-fun shapeStyle(
-    fill: String? = null,
-    opacity: Double? = null,
-    stroke: String? = null,
-    strokeWidth: Double? = null,
-    lineStyle: LineStyleConstant? = null
-): RoomVisual.ShapeStyle = jsObject {
-    this.fill = fill
-    this.opacity = opacity
-    this.stroke = stroke
-    this.strokeWidth = strokeWidth
-    this.lineStyle = lineStyle
-}
-
-fun circleStyle(
-    radius: Double? = null,
-    fill: String? = null,
-    opacity: Double? = null,
-    stroke: String? = null,
-    strokeWidth: Double? = null,
-    lineStyle: LineStyleConstant? = null
-): RoomVisual.CircleStyle = jsObject {
-    this.radius = radius
-    this.fill = fill
-    this.opacity = opacity
-    this.stroke = stroke
-    this.strokeWidth = strokeWidth
-    this.lineStyle = lineStyle
-}
-
-fun textStyle(
-    color: String? = null,
-    font: String? = null,
-    stroke: String? = null,
-    strokeWidth: Double? = null,
-    backgroundColor: String? = null,
-    backgroundPadding: String? = null,
-    align: TextAlignConstant? = null,
-    opacity: Double? = null
-): RoomVisual.TextStyle = jsObject {
-    this.color = color
-    this.font = font
-    this.stroke = stroke
-    this.strokeWidth = strokeWidth
-    this.backgroundColor = backgroundColor
-    this.backgroundPadding = backgroundPadding
-    this.align = align
-    this.opacity = opacity
 }

--- a/src/main/kotlin/screeps/utils/Options.kt
+++ b/src/main/kotlin/screeps/utils/Options.kt
@@ -1,7 +1,73 @@
 package screeps.utils
 
 import screeps.api.Game
+import screeps.api.LineStyleConstant
+import screeps.api.RoomVisual
+import screeps.api.TextAlignConstant
 
 fun routeOptions(routeCallback: (roomName: String, fromRoomName: String) -> Double): Game.Map.RouteOptions = jsObject {
     this.routeCallback = routeCallback
+}
+
+// RoomVisual style options
+fun lineStyle(
+    width: Double? = null,
+    color: String? = null,
+    opacity: Double? = null,
+    lineStyle: LineStyleConstant? = null
+): RoomVisual.LineStyle = jsObject {
+    this.width = width
+    this.color = color
+    this.opacity = opacity
+    this.lineStyle = lineStyle
+}
+
+fun shapeStyle(
+    fill: String? = null,
+    opacity: Double? = null,
+    stroke: String? = null,
+    strokeWidth: Double? = null,
+    lineStyle: LineStyleConstant? = null
+): RoomVisual.ShapeStyle = jsObject {
+    this.fill = fill
+    this.opacity = opacity
+    this.stroke = stroke
+    this.strokeWidth = strokeWidth
+    this.lineStyle = lineStyle
+}
+
+fun circleStyle(
+    radius: Double? = null,
+    fill: String? = null,
+    opacity: Double? = null,
+    stroke: String? = null,
+    strokeWidth: Double? = null,
+    lineStyle: LineStyleConstant? = null
+): RoomVisual.CircleStyle = jsObject {
+    this.radius = radius
+    this.fill = fill
+    this.opacity = opacity
+    this.stroke = stroke
+    this.strokeWidth = strokeWidth
+    this.lineStyle = lineStyle
+}
+
+fun textStyle(
+    color: String? = null,
+    font: String? = null,
+    stroke: String? = null,
+    strokeWidth: Double? = null,
+    backgroundColor: String? = null,
+    backgroundPadding: String? = null,
+    align: TextAlignConstant? = null,
+    opacity: Double? = null
+): RoomVisual.TextStyle = jsObject {
+    this.color = color
+    this.font = font
+    this.stroke = stroke
+    this.strokeWidth = strokeWidth
+    this.backgroundColor = backgroundColor
+    this.backgroundPadding = backgroundPadding
+    this.align = align
+    this.opacity = opacity
 }

--- a/src/main/kotlin/screeps/utils/Utils.kt
+++ b/src/main/kotlin/screeps/utils/Utils.kt
@@ -13,25 +13,5 @@ fun <T> jsonToMap(json: Json): Map<String, T> {
     return map
 }
 
-class VisualizePath(val visualizePathStyle: Style = Style(stroke = "#ffaa00")) {
-    constructor(stroke: String) : this(Style(stroke))
-}
-
-enum class LineStyle {
-    SOLID,
-    DASHED,
-    DOTTED
-}
-
-class Style(
-    val stroke: String = "#ffffff",
-    val fill: String? = null,
-    lineStyle: LineStyle = LineStyle.DASHED,
-    val strokeWidth: Double = 0.1,
-    val opacity: Double = 0.5
-) {
-    val lineStyle: String? = if (lineStyle == LineStyle.SOLID) null else lineStyle.name.toLowerCase()
-}
-
 fun RoomPosition.copy(x: Int = this.x, y: Int = this.y, name: String = this.roomName) =
     RoomPosition(x, y, name)


### PR DESCRIPTION
Adds interfaces for all style options and also helpers in `utils.Options`.

I do propose moving the `RoomVisual.*Style` interfaces into an `api.Options` file, together with other option interfaces.