### PR TITLE
Work through all types to ensure consistency

### DIFF
--- a/src/main/kotlin/screeps/api/Constants.kt
+++ b/src/main/kotlin/screeps/api/Constants.kt
@@ -268,6 +268,7 @@ external val SUBSCRIPTION_TOKEN: TradableConstant
 external interface TerrainConstant : StringConstant
 external interface LineStyleConstant : StringConstant
 external interface TextAlignConstant : StringConstant
+external interface AlgorithmConstant : StringConstant
 
 val TERRAIN_PLAIN: TerrainConstant = "plain".unsafeCast<TerrainConstant>()
 val TERRAIN_SWAMP: TerrainConstant = "swamp".unsafeCast<TerrainConstant>()
@@ -280,3 +281,5 @@ val LINE_STYLE_SOLID: LineStyleConstant = undefined.unsafeCast<LineStyleConstant
 val TEXT_ALIGN_LEFT: TextAlignConstant = "left".unsafeCast<TextAlignConstant>()
 val TEXT_ALIGN_CENTER: TextAlignConstant = "center".unsafeCast<TextAlignConstant>()
 val TEXT_ALIGN_RIGHT: TextAlignConstant = "right".unsafeCast<TextAlignConstant>()
+val ALGORITHM_ASTAR: AlgorithmConstant = "astar".unsafeCast<AlgorithmConstant>()
+val ALGORITHM_DIJKSTRA: AlgorithmConstant = "dijkstra".unsafeCast<AlgorithmConstant>()

--- a/src/main/kotlin/screeps/api/Creep.kt
+++ b/src/main/kotlin/screeps/api/Creep.kt
@@ -32,7 +32,7 @@ abstract external class Creep : RoomObject, Owned, Attackable, Container, Identi
     fun move(direction: DirectionConstant): ScreepsReturnCode
     fun moveByPath(path: Array<Room.PathStep>): ScreepsReturnCode
     fun moveByPath(serializedPath: String): ScreepsReturnCode
-    fun moveTo(target: RoomPosition, opts: MoveToOptions = definedExternally): ScreepsReturnCode
+    fun moveTo(target: NavigationTarget, opts: MoveToOptions = definedExternally): ScreepsReturnCode
     fun moveTo(x: Int, y: Int, opts: MoveToOptions = definedExternally): ScreepsReturnCode
     fun notifyWhenAttacked(enable: Boolean): ScreepsReturnCode
     fun pickup(target: Resource): ScreepsReturnCode

--- a/src/main/kotlin/screeps/api/Creep.kt
+++ b/src/main/kotlin/screeps/api/Creep.kt
@@ -6,7 +6,7 @@ import screeps.api.structures.StructureController
 
 abstract external class Creep : RoomObject, Owned, Attackable, Container, Identifiable {
     val body: Array<BodyPart>
-    val carry: Storage
+    val carry: StoreDefinition
     val carryCapacity: Int
     val fatigue: Int
     val memory: CreepMemory
@@ -51,11 +51,6 @@ abstract external class Creep : RoomObject, Owned, Attackable, Container, Identi
         resourceType: ResourceConstant,
         amount: Int = definedExternally
     ): ScreepsReturnCode
-}
-
-external interface Storage {
-    val energy: Int
-    val power: Int?
 }
 
 external interface BodyPart {

--- a/src/main/kotlin/screeps/api/Creep.kt
+++ b/src/main/kotlin/screeps/api/Creep.kt
@@ -2,6 +2,7 @@ package screeps.api
 
 import screeps.api.structures.Structure
 import screeps.api.structures.StructureController
+import screeps.utils.Style
 
 
 abstract external class Creep : RoomObject, Owned, Attackable, Container, Identifiable {
@@ -29,10 +30,10 @@ abstract external class Creep : RoomObject, Owned, Attackable, Container, Identi
     fun harvest(target: Mineral): ScreepsReturnCode
     fun heal(target: Creep): ScreepsReturnCode
     fun move(direction: DirectionConstant): ScreepsReturnCode
-    fun moveByPath(path: Array<PathStep>): ScreepsReturnCode
+    fun moveByPath(path: Array<Room.PathStep>): ScreepsReturnCode
     fun moveByPath(serializedPath: String): ScreepsReturnCode
-    fun moveTo(target: RoomPosition, opts: MoveToOpts = definedExternally): ScreepsReturnCode
-    fun moveTo(x: Int, y: Int, opts: MoveToOpts = definedExternally): ScreepsReturnCode
+    fun moveTo(target: RoomPosition, opts: MoveToOptions = definedExternally): ScreepsReturnCode
+    fun moveTo(x: Int, y: Int, opts: MoveToOptions = definedExternally): ScreepsReturnCode
     fun notifyWhenAttacked(enable: Boolean): ScreepsReturnCode
     fun pickup(target: Resource): ScreepsReturnCode
     fun rangedAttack(target: Creep): ScreepsReturnCode
@@ -51,26 +52,18 @@ abstract external class Creep : RoomObject, Owned, Attackable, Container, Identi
         resourceType: ResourceConstant,
         amount: Int = definedExternally
     ): ScreepsReturnCode
+
+    interface BodyPart {
+        val boost: String?
+        val type: BodyPartConstant
+        val hits: Int
+    }
+
 }
 
-external interface BodyPart {
-    val boost: String?
-    val type: BodyPartConstant
-    val hits: Int
+external interface MoveToOptions : FindPathOptions {
+    val reusePath: Int?
+    val serializeMemory: Boolean?
+    val noPathFinding: Boolean?
+    val visualizePathStyle: Style?
 }
-
-class MoveToOpts(
-    val reusePath: Int = 5,
-    val serializeMemory: Boolean = true,
-    val noPathFinding: Boolean = false,
-    val visualizePathStyle: RoomVisual.ShapeStyle,
-
-    val ignoreCreeps: Boolean = false,
-    val ignoreDestructibleStructures: Boolean = false,
-    val ignoreRoads: Boolean = false,
-    val maxOps: Int = 2000,
-    val serialize: Boolean = false,
-    val maxRooms: Int = 16,
-    val heuristicWeight: Double = 1.2,
-    val range: Int = 0
-) //some options are not included: plaincost, swampcost and costCallback

--- a/src/main/kotlin/screeps/api/Flag.kt
+++ b/src/main/kotlin/screeps/api/Flag.kt
@@ -6,9 +6,8 @@ abstract external class Flag : RoomObject {
     val name: String
     val secondaryColor: ColorConstant
     fun remove() // always ok
-    fun setColor(color: ColorConstant): ScreepsReturnCode
-    fun setColor(color: ColorConstant, secondaryColor: ColorConstant): ScreepsReturnCode
-    fun setPosition(position: RoomPosition): ScreepsReturnCode
+    fun setColor(color: ColorConstant, secondaryColor: ColorConstant = definedExternally): ScreepsReturnCode
     fun setPosition(x: Int, y: Int): ScreepsReturnCode
-    fun setPosition(roomObject: RoomObject): ScreepsReturnCode
+    fun setPosition(pos: RoomPosition): ScreepsReturnCode
+    fun setPosition(pos: HasPosition): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/Game.kt
+++ b/src/main/kotlin/screeps/api/Game.kt
@@ -93,8 +93,8 @@ external object Game {
 
     interface Map {
         fun describeExits(roomName: String): Record<DirectionConstant, String>
-        fun findExit(fromRoom: String, toRoom: String, opts: RouteOptions? = definedExternally): ExitConstant
-        fun getRoomLinearDistance(roomName1: String, roomName2: String, continuous: Boolean? = definedExternally): Int
+        fun findExit(fromRoom: String, toRoom: String, opts: RouteOptions = definedExternally): ExitConstant
+        fun getRoomLinearDistance(roomName1: String, roomName2: String, continuous: Boolean = definedExternally): Int
         fun getTerrainAt(x: Int, y: Int, roomName: String): TerrainConstant
         fun getTerrainAt(pos: RoomPosition): TerrainConstant
         fun getWorldSize(): Int

--- a/src/main/kotlin/screeps/api/GeneralTypes.kt
+++ b/src/main/kotlin/screeps/api/GeneralTypes.kt
@@ -1,0 +1,7 @@
+package screeps.api
+
+external interface StoreDefinition {
+    val energy: Int
+    val power: Int?
+}
+

--- a/src/main/kotlin/screeps/api/GeneralTypes.kt
+++ b/src/main/kotlin/screeps/api/GeneralTypes.kt
@@ -5,3 +5,7 @@ external interface StoreDefinition {
     val power: Int?
 }
 
+external interface FilterOption<T> {
+    var filter: ((T) -> Boolean)?
+}
+

--- a/src/main/kotlin/screeps/api/Market.kt
+++ b/src/main/kotlin/screeps/api/Market.kt
@@ -16,13 +16,13 @@ external interface Market {
         resourceType: TradableConstant,
         price: Double,
         totalAmount: Int,
-        roomName: String? = definedExternally
+        roomName: String = definedExternally
     ): ScreepsReturnCode
 
-    fun deal(orderId: String, amount: Int, targetRoomName: String? = definedExternally): ScreepsReturnCode
+    fun deal(orderId: String, amount: Int, targetRoomName: String = definedExternally): ScreepsReturnCode
     fun extendOrder(orderId: String, addAmount: Int): ScreepsReturnCode
-    fun getAllOrders(filter: Order.Filter? = definedExternally): Array<Order>
-    fun getAllOrders(filter: ((o: Order) -> Boolean)? = definedExternally): Array<Order>
+    fun getAllOrders(filter: Order.Filter = definedExternally): Array<Order>
+    fun getAllOrders(filter: ((o: Order) -> Boolean) = definedExternally): Array<Order>
     fun getAllOrders(): Array<Order>
     fun getOrderById(id: String): Order?
 

--- a/src/main/kotlin/screeps/api/PathFinder.kt
+++ b/src/main/kotlin/screeps/api/PathFinder.kt
@@ -3,10 +3,10 @@
 package screeps.api
 
 external object PathFinder {
-    fun search(origin: RoomPosition, goal: RoomPosition, options: Options = definedExternally): Path
-    fun search(origin: RoomPosition, goal: Array<RoomPosition>, options: Options = definedExternally): Path
-    fun search(origin: RoomPosition, goal: GoalWithRange, options: Options = definedExternally): Path
-    fun search(origin: RoomPosition, goal: Array<GoalWithRange>, options: Options = definedExternally): Path
+    fun search(origin: RoomPosition, goal: RoomPosition, options: SearchOptions = definedExternally): Path
+    fun search(origin: RoomPosition, goal: Array<RoomPosition>, options: SearchOptions = definedExternally): Path
+    fun search(origin: RoomPosition, goal: GoalWithRange, options: SearchOptions = definedExternally): Path
+    fun search(origin: RoomPosition, goal: Array<GoalWithRange>, options: SearchOptions = definedExternally): Path
 
     class CostMatrix {
         fun set(x: Int, y: Int, cost: Int)
@@ -25,17 +25,6 @@ external object PathFinder {
     }
 
 
-    interface Options {
-        var roomCallback: ((String) -> CostMatrix)?
-        var plainCost: Int?
-        var swampCost: Int?
-        var flee: Boolean?
-        var maxOps: Int?
-        var maxRooms: Int?
-        var maxCost: Int?
-        var heuristicWeight: Double?
-    }
-
     interface Path {
         val path: Array<RoomPosition>
         val ops: Int
@@ -43,3 +32,15 @@ external object PathFinder {
         val incomplete: Boolean
     }
 }
+
+interface SearchOptions {
+    var roomCallback: ((String) -> PathFinder.CostMatrix)?
+    var plainCost: Int?
+    var swampCost: Int?
+    var flee: Boolean?
+    var maxOps: Int?
+    var maxRooms: Int?
+    var maxCost: Int?
+    var heuristicWeight: Double?
+}
+

--- a/src/main/kotlin/screeps/api/PathFinder.kt
+++ b/src/main/kotlin/screeps/api/PathFinder.kt
@@ -3,10 +3,10 @@
 package screeps.api
 
 external object PathFinder {
-    fun search(origin: RoomPosition, goal: RoomPosition, options: Options? = definedExternally): Path
-    fun search(origin: RoomPosition, goal: Array<RoomPosition>, options: Options? = definedExternally): Path
-    fun search(origin: RoomPosition, goal: GoalWithRange, options: Options? = definedExternally): Path
-    fun search(origin: RoomPosition, goal: Array<GoalWithRange>, options: Options? = definedExternally): Path
+    fun search(origin: RoomPosition, goal: RoomPosition, options: Options = definedExternally): Path
+    fun search(origin: RoomPosition, goal: Array<RoomPosition>, options: Options = definedExternally): Path
+    fun search(origin: RoomPosition, goal: GoalWithRange, options: Options = definedExternally): Path
+    fun search(origin: RoomPosition, goal: Array<GoalWithRange>, options: Options = definedExternally): Path
 
     class CostMatrix {
         fun set(x: Int, y: Int, cost: Int)

--- a/src/main/kotlin/screeps/api/RawMemory.kt
+++ b/src/main/kotlin/screeps/api/RawMemory.kt
@@ -10,7 +10,7 @@ external object RawMemory {
     fun get(): String
     fun set(value: String)
     fun setActiveSegments(ids: Array<Int>)
-    fun setActiveForeignSegment(username: String, id: Int? = definedExternally)
+    fun setActiveForeignSegment(username: String, id: Int = definedExternally)
     fun setDefaultPublicSegment(id: Int?)
     fun setPublicSegments(ids: Array<Int>)
 

--- a/src/main/kotlin/screeps/api/RoomPosition.kt
+++ b/src/main/kotlin/screeps/api/RoomPosition.kt
@@ -66,10 +66,6 @@ external class RoomPosition(x: Int, y: Int, roomName: String) : NavigationTarget
     }
 }
 
-external interface FilterOption<T> {
-    var filter: ((T) -> Boolean)?
-}
-
 external interface FindClosestByPathOptions<T> : FindPathOptions, FilterOption<T> {
     var algorithm: AlgorithmConstant?
 }

--- a/src/main/kotlin/screeps/api/RoomPosition.kt
+++ b/src/main/kotlin/screeps/api/RoomPosition.kt
@@ -1,5 +1,7 @@
 package screeps.api
 
+import screeps.api.structures.Structure
+
 external class RoomPosition(x: Int, y: Int, roomName: String) : NavigationTarget {
     val roomName: String
     val x: Int
@@ -15,20 +17,28 @@ external class RoomPosition(x: Int, y: Int, roomName: String) : NavigationTarget
 
     fun <T : RoomObject> findClosestByPath(
         objects: Array<RoomObject>,
-        opts: dynamic = definedExternally
+        opts: FindClosestByPathOptions<T> = definedExternally
     ): T?
 
-    fun <T : RoomObject> findClosestByPath(type: FindConstant, opts: dynamic = definedExternally): T?
+    fun <T : RoomObject> findClosestByPath(
+        type: FindConstant,
+        opts: FindClosestByPathOptions<T> = definedExternally
+    ): T?
 
     fun <T : RoomObject> findClosestByRange(
         type: FindConstant,
         objects: Array<RoomObject>,
-        opts: dynamic = definedExternally
+        opts: FilterOption<T> = definedExternally
     ): T?
 
-    fun <T : RoomObject> findClosestByRange(type: FindConstant, opts: dynamic = definedExternally): T?
+    fun <T : RoomObject> findClosestByRange(type: FindConstant, opts: FilterOption<T> = definedExternally): T?
 
-    fun <T : RoomObject> findInRange(type: FindConstant, range: Int, opts: Filter = definedExternally): Array<T>
+    fun <T : RoomObject> findInRange(
+        type: FindConstant,
+        range: Int,
+        opts: FilterOption<T> = definedExternally
+    ): Array<T>
+
     fun getDirectionTo(x: Int, y: Int): DirectionConstant
     fun getDirectionTo(target: RoomPosition): DirectionConstant
     fun getDirectionTo(target: RoomObject): DirectionConstant
@@ -43,8 +53,23 @@ external class RoomPosition(x: Int, y: Int, roomName: String) : NavigationTarget
     fun isNearTo(x: Int, y: Int): Boolean
     fun isNearTo(target: RoomPosition): Boolean
     fun isNearTo(target: RoomObject): Boolean
-    fun look(): Array<LookAt>
+    fun look(): Array<Look>
     fun <T> lookFor(type: LookConstant): Array<T>?
+
+    interface Look {
+        val type: LookConstant
+        val creep: Creep?
+        val structure: Structure?
+        val terrain: String?
+        val constructionSite: ConstructionSite?
+        val resource: Resource?
+    }
 }
 
-class Filter(val filter: dynamic)
+external interface FilterOption<T> {
+    var filter: ((T) -> Boolean)?
+}
+
+external interface FindClosestByPathOptions<T> : FindPathOptions, FilterOption<T> {
+    var algorithm: AlgorithmConstant?
+}

--- a/src/main/kotlin/screeps/api/Tombstone.kt
+++ b/src/main/kotlin/screeps/api/Tombstone.kt
@@ -3,5 +3,5 @@ package screeps.api
 abstract external class Tombstone : RoomObject, Decaying, Container, Identifiable {
     val creep: Creep
     val deathTime: Int
-    val store: Storage
+    val store: StoreDefinition
 }

--- a/src/main/kotlin/screeps/api/structures/StructureContainer.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureContainer.kt
@@ -2,9 +2,9 @@ package screeps.api.structures
 
 import screeps.api.Container
 import screeps.api.Decaying
-import screeps.api.Storage
+import screeps.api.StoreDefinition
 
 abstract external class StructureContainer : Structure, Decaying, Container {
-    val store: Storage
+    val store: StoreDefinition
     val storeCapacity: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureController.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureController.kt
@@ -8,25 +8,25 @@ abstract external class StructureController : Structure, Owned {
     val level: Int
     val progress: Int
     val progressTotal: Int
-    val reservation: ReservationDefinition?
+    val reservation: Reservation?
     val safeMode: Int?
     val safeModeAvailable: Int
     val safeModeCooldown: Int?
-    val sign: SignDefinition?
+    val sign: Sign?
     val ticksToDowngrade: Int
     val upgradeBlocked: Int
     fun activateSafeMode(): ScreepsReturnCode
     fun unclaim(): ScreepsReturnCode
-}
 
-external interface ReservationDefinition {
-    var username: String
-    var ticksToEnd: Int
-}
+    interface Reservation {
+        var username: String
+        var ticksToEnd: Int
+    }
 
-external interface SignDefinition {
-    var username: String
-    var text: String
-    var time: Int
-    var datetime: Date
+    interface Sign {
+        var username: String
+        var text: String
+        var time: Int
+        var datetime: Date
+    }
 }

--- a/src/main/kotlin/screeps/api/structures/StructurePowerSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructurePowerSpawn.kt
@@ -4,11 +4,9 @@ import screeps.api.EnergyContainer
 import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
 
-/**
- * under development!
- */
 abstract external class StructurePowerSpawn : Structure, Owned, EnergyContainer {
     val power: Int
     val powerCapacity: Int
+    fun createPowerCreep(name: String): ScreepsReturnCode
     fun processPower(): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
@@ -46,11 +46,11 @@ abstract external class StructureSpawn : Structure, Owned, SpawnEnergyProvider {
 
         fun cancel(): ScreepsReturnCode
     }
+}
 
-    interface SpawnOptions {
-        var memory: CreepMemory?
-        var energyStructures: Array<SpawnEnergyProvider>?
-        var dryRun: Boolean?
-        var directions: Array<DirectionConstant>?
-    }
+external interface SpawnOptions {
+    var memory: CreepMemory?
+    var energyStructures: Array<SpawnEnergyProvider>?
+    var dryRun: Boolean?
+    var directions: Array<DirectionConstant>?
 }

--- a/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
@@ -5,18 +5,16 @@ import screeps.api.*
 abstract external class StructureSpawn : Structure, Owned, SpawnEnergyProvider {
     val memory: SpawnMemory
     val name: String
-
     val spawning: Spawning?
 
     /**
      * Start the creep spawning process. The required energy amount can be withdrawn from all spawns and utils in the room.
      */
-    fun spawnCreep(body: Array<BodyPartConstant>, name: String): ScreepsReturnCode
-
-    /**
-     * Start the creep spawning process. The required energy amount can be withdrawn from all spawns and utils in the room.
-     */
-    fun spawnCreep(body: Array<BodyPartConstant>, name: String, opts: SpawnOptions): ScreepsReturnCode
+    fun spawnCreep(
+        body: Array<BodyPartConstant>,
+        name: String,
+        opts: SpawnOptions? = definedExternally
+    ): ScreepsReturnCode
 
     /**
      * Kill the creep and drop up to 100% of resources spent on its spawning and boosting depending on remaining life time.
@@ -39,24 +37,20 @@ abstract external class StructureSpawn : Structure, Owned, SpawnEnergyProvider {
      * Renewing a creep removes all of its boosts.
      */
     fun renewCreep(target: Creep): ScreepsReturnCode
+
+    interface Spawning {
+        val directions: Array<DirectionConstant>
+        val name: String
+        val needTime: Int
+        val remainingTime: Int
+
+        fun cancel(): ScreepsReturnCode
+    }
+
+    interface SpawnOptions {
+        var memory: CreepMemory?
+        var energyStructures: Array<SpawnEnergyProvider>?
+        var dryRun: Boolean?
+        var directions: Array<DirectionConstant>?
+    }
 }
-
-external class Spawning {
-    val directions: Array<DirectionConstant>
-    val name: String
-    val needTime: Int
-    val remainingTime: Int
-
-    fun cancel(): ScreepsReturnCode
-}
-
-interface SpawnOptions {
-    val memory: CreepMemory?
-}
-
-open class FullSpawnOptions(
-    override val memory: CreepMemory? = null,
-    open val energyContainingStructure: Array<SpawnEnergyProvider>? = null,
-    open val dryRun: Boolean = false,
-    open val directions: Array<DirectionConstant>? = null
-) : SpawnOptions

--- a/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
@@ -13,7 +13,7 @@ abstract external class StructureSpawn : Structure, Owned, SpawnEnergyProvider {
     fun spawnCreep(
         body: Array<BodyPartConstant>,
         name: String,
-        opts: SpawnOptions? = definedExternally
+        opts: SpawnOptions = definedExternally
     ): ScreepsReturnCode
 
     /**

--- a/src/main/kotlin/screeps/api/structures/StructureStorage.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureStorage.kt
@@ -2,9 +2,9 @@ package screeps.api.structures
 
 import screeps.api.Container
 import screeps.api.Owned
-import screeps.api.Storage
+import screeps.api.StoreDefinition
 
 abstract external class StructureStorage : Structure, Owned, Container {
-    val store: Storage
+    val store: StoreDefinition
     val storeCapacity: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
@@ -4,7 +4,7 @@ import screeps.api.*
 
 abstract external class StructureTerminal : Structure, Owned, Container {
     val cooldown: Int
-    val store: Storage
+    val store: StoreDefinition
     val storeCapacity: Int
     fun send(
         resourceType: ResourceConstant,

--- a/src/main/kotlin/screeps/utils/Options.kt
+++ b/src/main/kotlin/screeps/utils/Options.kt
@@ -1,7 +1,23 @@
 package screeps.utils
 
+import screeps.api.CreepMemory
+import screeps.api.DirectionConstant
 import screeps.api.Game
+import screeps.api.SpawnEnergyProvider
+import screeps.api.structures.StructureSpawn
 
 fun routeOptions(routeCallback: (roomName: String, fromRoomName: String) -> Double): Game.Map.RouteOptions = jsObject {
     this.routeCallback = routeCallback
+}
+
+fun spawnOwptions(
+    memory: CreepMemory? = null,
+    energyStructures: Array<SpawnEnergyProvider>? = null,
+    dryRun: Boolean? = null,
+    directions: Array<DirectionConstant>? = null
+): StructureSpawn.SpawnOptions = jsObject {
+    this.memory = memory
+    this.energyStructures = energyStructures
+    this.dryRun = dryRun
+    this.directions = directions
 }

--- a/src/main/kotlin/screeps/utils/Options.kt
+++ b/src/main/kotlin/screeps/utils/Options.kt
@@ -1,23 +1,7 @@
 package screeps.utils
 
-import screeps.api.CreepMemory
-import screeps.api.DirectionConstant
 import screeps.api.Game
-import screeps.api.SpawnEnergyProvider
-import screeps.api.structures.StructureSpawn
 
 fun routeOptions(routeCallback: (roomName: String, fromRoomName: String) -> Double): Game.Map.RouteOptions = jsObject {
     this.routeCallback = routeCallback
-}
-
-fun spawnOwptions(
-    memory: CreepMemory? = null,
-    energyStructures: Array<SpawnEnergyProvider>? = null,
-    dryRun: Boolean? = null,
-    directions: Array<DirectionConstant>? = null
-): StructureSpawn.SpawnOptions = jsObject {
-    this.memory = memory
-    this.energyStructures = energyStructures
-    this.dryRun = dryRun
-    this.directions = directions
 }


### PR DESCRIPTION
I open a PR for discussion.
I intend to work through all types and make them consistent with the library and API. Should be mostly small changes.

I currently propose these guidelines:
- Return type interfaces should be a sub interface of the class/interface that uses it. The API does this with `StructureSpawn.Spawning`, see [api/StructureSpawn.spawning](https://docs.screeps.com/api/#StructureSpawn.spawning).
  I don't think it is an issue to nest these types, as you will never have to actually type them as a user, they are mostly middleman types. In the rare case that you do have to type out a `Spawning` type, your IDE will autocomplete to either `StructureSpawn.Spawning` or it will import `StructureSpawn.Spawning` and then just leave it as `Spawning`.
- Any interface that the user has to pass to a function should be made a nullable mutable interface, as all properties are optional, see [StructureSpawn#L50](https://github.com/exaV/screeps-kotlin-types/blob/feature-typefix/src/main/kotlin/screeps/api/structures/StructureSpawn.kt#L50).
  We then add  a corresponding function in the `utils` package to help create this interface. It should be named the same as the interface, just with a lowercase starting letter, see [Options#L13](https://github.com/exaV/screeps-kotlin-types/blob/feature-typefix/src/main/kotlin/screeps/utils/Options.kt#L13).

We can consider moving any `*Options` interface to a separate file in the `api` package. But, the nice part of having them as a sub-interface is that it is clear where they are used, in case we have to change something later.
Again, the user should rarely have to type the name of these interfaces themselves.

Having options not be nullable (but still with default so they are optional) allows typescript to infer the interface for `jsObject`.
We can then do 
```kt
spawn.spawnCreep(body, name, jsObject {
  // `this` is inferred to be StructureSpawn.SpawnOptions
})
```