### PR TITLE
add Options implementation

### DIFF
--- a/src/main/kotlin/screeps/api/Game.kt
+++ b/src/main/kotlin/screeps/api/Game.kt
@@ -105,16 +105,17 @@ external object Game {
             val room: String
         }
 
-        interface RouteOptions : Options {
-            var routeCallback: (roomName: String, fromRoomName: String) -> Double
-        }
     }
+}
+
+external interface RouteOptions : Options {
+    var routeCallback: (roomName: String, fromRoomName: String) -> Double
 }
 
 fun Game.Map.findRoute(
     fromRoom: String,
     toRoom: String,
-    opts: Game.Map.RouteOptions? = null
+    opts: RouteOptions? = null
 ): Result<ScreepsReturnCode, Array<Game.Map.RouteResult>> {
     val res = this.asDynamic().findRoute(fromRoom, toRoom, opts)
     return if (res is Array<*>) Result.Value(res.unsafeCast<Array<Game.Map.RouteResult>>())

--- a/src/main/kotlin/screeps/api/Game.kt
+++ b/src/main/kotlin/screeps/api/Game.kt
@@ -105,7 +105,7 @@ external object Game {
             val room: String
         }
 
-        interface RouteOptions {
+        interface RouteOptions : Options {
             var routeCallback: (roomName: String, fromRoomName: String) -> Double
         }
     }

--- a/src/main/kotlin/screeps/api/GeneralTypes.kt
+++ b/src/main/kotlin/screeps/api/GeneralTypes.kt
@@ -11,6 +11,12 @@ external interface FilterOption<T> {
     var filter: ((T) -> Boolean)?
 }
 
+/**
+ * Indicates type is an external interface with only *mutable and nullable* properties.
+ * Thus it can be safely instantiated by [screeps.utils.jsObject]
+ *
+ * We provide the function [options] to create such objects
+ */
 external interface Options
 
 fun <T : Options> options(init: T.() -> Unit): T = jsObject(init).unsafeCast<T>()

--- a/src/main/kotlin/screeps/api/GeneralTypes.kt
+++ b/src/main/kotlin/screeps/api/GeneralTypes.kt
@@ -1,5 +1,7 @@
 package screeps.api
 
+import screeps.utils.jsObject
+
 external interface StoreDefinition {
     val energy: Int
     val power: Int?
@@ -9,3 +11,6 @@ external interface FilterOption<T> {
     var filter: ((T) -> Boolean)?
 }
 
+external interface Options
+
+fun <T : Options> options(init: T.() -> Unit): T = jsObject(init).unsafeCast<T>()

--- a/src/main/kotlin/screeps/api/PathFinder.kt
+++ b/src/main/kotlin/screeps/api/PathFinder.kt
@@ -33,7 +33,7 @@ external object PathFinder {
     }
 }
 
-interface SearchOptions {
+interface SearchOptions : Options {
     var roomCallback: ((String) -> PathFinder.CostMatrix)?
     var plainCost: Int?
     var swampCost: Int?
@@ -43,4 +43,3 @@ interface SearchOptions {
     var maxCost: Int?
     var heuristicWeight: Double?
 }
-

--- a/src/main/kotlin/screeps/api/PathFinder.kt
+++ b/src/main/kotlin/screeps/api/PathFinder.kt
@@ -33,7 +33,7 @@ external object PathFinder {
     }
 }
 
-interface SearchOptions : Options {
+external interface SearchOptions : Options {
     var roomCallback: ((String) -> PathFinder.CostMatrix)?
     var plainCost: Int?
     var swampCost: Int?

--- a/src/main/kotlin/screeps/api/Room.kt
+++ b/src/main/kotlin/screeps/api/Room.kt
@@ -63,7 +63,7 @@ fun Room.lookAtArea(top: Int, left: Int, bottom: Int, right: Int): LookAtAreaRes
 fun Room.lookAtAreaAsArray(top: Int, left: Int, bottom: Int, right: Int): Array<Room.LookAtAreaArrayItem> =
     this.asDynamic().lookAtArea(top, left, bottom, right, true).unsafeCast<Array<Room.LookAtAreaArrayItem>>()
 
-external interface FindPathOptions {
+external interface FindPathOptions : Options {
     var ignoreCreeps: Boolean?
     var ignoreDestructibleStructures: Boolean?
     var ignoreRoads: Boolean?

--- a/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
@@ -48,7 +48,7 @@ abstract external class StructureSpawn : Structure, Owned, SpawnEnergyProvider {
     }
 }
 
-external interface SpawnOptions {
+external interface SpawnOptions : Options {
     var memory: CreepMemory?
     var energyStructures: Array<SpawnEnergyProvider>?
     var dryRun: Boolean?

--- a/src/main/kotlin/screeps/utils/Options.kt
+++ b/src/main/kotlin/screeps/utils/Options.kt
@@ -1,7 +1,0 @@
-package screeps.utils
-
-import screeps.api.Game
-
-fun routeOptions(routeCallback: (roomName: String, fromRoomName: String) -> Double): Game.Map.RouteOptions = jsObject {
-    this.routeCallback = routeCallback
-}

--- a/src/test/kotlin/memory/TestDelegatesWithDefault.kt
+++ b/src/test/kotlin/memory/TestDelegatesWithDefault.kt
@@ -1,6 +1,6 @@
 import screeps.api.CreepMemory
 import screeps.api.SearchOptions
-import screeps.utils.jsObject
+import screeps.api.options
 import screeps.utils.memory.memory
 import screeps.utils.memory.memoryOrDefault
 import kotlin.test.Test
@@ -11,7 +11,7 @@ class TestDelegatesWithDefault {
 
     var CreepMemory.priority: Int by memoryOrDefault { 0 }
     var CreepMemory.options: SearchOptions by memoryOrDefault {
-        jsObject<SearchOptions> {
+        options<SearchOptions> {
             maxCost = 10
         }
     }

--- a/src/test/kotlin/memory/TestNullableDelegates.kt
+++ b/src/test/kotlin/memory/TestNullableDelegates.kt
@@ -1,9 +1,5 @@
-import screeps.api.CreepMemory
-import screeps.api.Record
-import screeps.api.SearchOptions
-import screeps.api.get
+import screeps.api.*
 import screeps.utils.contains
-import screeps.utils.jsObject
 import screeps.utils.memory.memory
 import kotlin.test.*
 
@@ -51,7 +47,7 @@ class TestNullableDelegates {
         assertNull(memory.options)
         assertNull(memory.options?.maxCost)
 
-        memory.options = jsObject<SearchOptions> {
+        memory.options = options<SearchOptions> {
             maxCost = 15
         }
         assertEquals(15, memory.options?.maxCost)


### PR DESCRIPTION
Adds an `Options` interface to let us restrict what can be created with the `options` function.
Interfaces that implement `Options` should have only var properties, and they should be nullable.
We need the `Options` interface to ensure typesafety.
The previous `jsObject` is too unsafe.
Adds a function, `options`, to allow for easy creation of option objects.
Kotlin automatically infers what option type is needed if the function is used as an argument to a method that takes `Options`.

Should await #11 