### PR TITLE
Fix trait usage in API

### DIFF
--- a/src/main/kotlin/screeps/api/Creep.kt
+++ b/src/main/kotlin/screeps/api/Creep.kt
@@ -3,7 +3,7 @@ package screeps.api
 import screeps.api.structures.Structure
 import screeps.api.structures.StructureController
 
-abstract external class Creep : RoomObject, Owned, Attackable, Container, Identifiable {
+abstract external class Creep : RoomObject, Owned, Attackable, Identifiable {
     val body: Array<BodyPart>
     val carry: StoreDefinition
     val carryCapacity: Int
@@ -43,10 +43,17 @@ abstract external class Creep : RoomObject, Owned, Attackable, Container, Identi
     fun say(message: String, toPublic: Boolean = definedExternally): ScreepsReturnCode
     fun signController(controller: StructureController, text: String): ScreepsReturnCode
     fun suicide(): ScreepsReturnCode
-    fun transfer(target: Container, resourceType: ResourceConstant, amount: Int = definedExternally): ScreepsReturnCode
+    fun transfer(target: Structure, resourceType: ResourceConstant, amount: Int = definedExternally): ScreepsReturnCode
+    fun transfer(target: Creep, resourceType: ResourceConstant, amount: Int = definedExternally): ScreepsReturnCode
     fun upgradeController(controller: StructureController): ScreepsReturnCode
     fun withdraw(
-        structure: Container,
+        target: Structure,
+        resourceType: ResourceConstant,
+        amount: Int = definedExternally
+    ): ScreepsReturnCode
+
+    fun withdraw(
+        target: Tombstone,
         resourceType: ResourceConstant,
         amount: Int = definedExternally
     ): ScreepsReturnCode

--- a/src/main/kotlin/screeps/api/GeneralTypes.kt
+++ b/src/main/kotlin/screeps/api/GeneralTypes.kt
@@ -2,9 +2,8 @@ package screeps.api
 
 import screeps.utils.jsObject
 
-external interface StoreDefinition {
+external interface StoreDefinition : Record<ResourceConstant, Int> {
     val energy: Int
-    val power: Int?
 }
 
 external interface FilterOption<T> {

--- a/src/main/kotlin/screeps/api/Tombstone.kt
+++ b/src/main/kotlin/screeps/api/Tombstone.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-abstract external class Tombstone : RoomObject, Decaying, Container, Identifiable {
+abstract external class Tombstone : RoomObject, Decaying, Identifiable {
     val creep: Creep
     val deathTime: Int
     val store: StoreDefinition

--- a/src/main/kotlin/screeps/api/Traits.kt
+++ b/src/main/kotlin/screeps/api/Traits.kt
@@ -31,11 +31,7 @@ external interface HasPosition : NavigationTarget {
     val pos: RoomPosition
 }
 
-external interface Container
-
-external interface EnergyContainer : Container {
+external interface EnergyContainer {
     val energy: Int
     val energyCapacity: Int
 }
-
-external interface SpawnEnergyProvider : EnergyContainer

--- a/src/main/kotlin/screeps/api/structures/StructureContainer.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureContainer.kt
@@ -1,10 +1,9 @@
 package screeps.api.structures
 
-import screeps.api.Container
 import screeps.api.Decaying
 import screeps.api.StoreDefinition
 
-abstract external class StructureContainer : Structure, Decaying, Container {
+abstract external class StructureContainer : Structure, Decaying {
     val store: StoreDefinition
     val storeCapacity: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureExtension.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureExtension.kt
@@ -1,6 +1,6 @@
 package screeps.api.structures
 
+import screeps.api.EnergyContainer
 import screeps.api.Owned
-import screeps.api.SpawnEnergyProvider
 
-abstract external class StructureExtension : Structure, Owned, SpawnEnergyProvider
+abstract external class StructureExtension : Structure, Owned, EnergyContainer

--- a/src/main/kotlin/screeps/api/structures/StructurePowerBank.kt
+++ b/src/main/kotlin/screeps/api/structures/StructurePowerBank.kt
@@ -1,8 +1,7 @@
 package screeps.api.structures
 
-import screeps.api.Container
 import screeps.api.Decaying
 
-abstract external class StructurePowerBank : Structure, Decaying, Container {
+abstract external class StructurePowerBank : Structure, Decaying {
     val power: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureSpawn : Structure, Owned, SpawnEnergyProvider {
+abstract external class StructureSpawn : Structure, Owned, EnergyContainer {
     val memory: SpawnMemory
     val name: String
     val spawning: Spawning?
@@ -50,7 +50,7 @@ abstract external class StructureSpawn : Structure, Owned, SpawnEnergyProvider {
 
 external interface SpawnOptions : Options {
     var memory: CreepMemory?
-    var energyStructures: Array<SpawnEnergyProvider>?
+    var energyStructures: Array<Structure>?
     var dryRun: Boolean?
     var directions: Array<DirectionConstant>?
 }

--- a/src/main/kotlin/screeps/api/structures/StructureStorage.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureStorage.kt
@@ -1,10 +1,9 @@
 package screeps.api.structures
 
-import screeps.api.Container
 import screeps.api.Owned
 import screeps.api.StoreDefinition
 
-abstract external class StructureStorage : Structure, Owned, Container {
+abstract external class StructureStorage : Structure, Owned {
     val store: StoreDefinition
     val storeCapacity: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
@@ -1,8 +1,11 @@
 package screeps.api.structures
 
-import screeps.api.*
+import screeps.api.Owned
+import screeps.api.ResourceConstant
+import screeps.api.ScreepsReturnCode
+import screeps.api.StoreDefinition
 
-abstract external class StructureTerminal : Structure, Owned, Container {
+abstract external class StructureTerminal : Structure, Owned {
     val cooldown: Int
     val store: StoreDefinition
     val storeCapacity: Int


### PR DESCRIPTION
#### Removes the Container and SpawnEnergyProvider traits:
They both cause issues when trying to get potential targets from a list of structures.
It is impossible to get a list that contains both Structure and Container, thus you could not easily use the target in multiple ways.

#### Make StoreDefinition a record:
Allows us to easily access all Resources on properties of type StoreDefinition.
We leave `energy` as the only property, as that is definitely existing.
Other resources can then be accessed using the Record's get function.
E.g. `creep.store[RESOURCE_OXYGEN]`.