### PR TITLE
Cannot write tests involving anything defined as external

### DIFF
--- a/src/test/kotlin/TestConstants.kt
+++ b/src/test/kotlin/TestConstants.kt
@@ -1,0 +1,14 @@
+import screeps.api.FIND_CREEPS
+import screeps.api.FIND_MY_STRUCTURES
+import screeps.api.value
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestConstants {
+
+    @Test
+    fun testConstants() {
+        assertEquals(126,FIND_MY_STRUCTURES.value or FIND_CREEPS.value)
+    }
+
+}


### PR DESCRIPTION
This simple test fails:

     assertEquals(126,FIND_MY_STRUCTURES.value or FIND_CREEPS.value)

with `ReferenceError: FIND_MY_STRUCTURES is not defined`

My guess is, that is because the constants are defined as external.

I think that should either be documented as an issue or be fixed.

Maybe we can define a npm dep for test-runtime which fixes that?