### PR TITLE
"Factories, new resources, NPC Strongholds" update support

### DIFF
--- a/src/main/kotlin/screeps/api/Constants.kt
+++ b/src/main/kotlin/screeps/api/Constants.kt
@@ -4,7 +4,6 @@ package screeps.api
 
 import screeps.api.structures.Structure
 import screeps.api.structures.StructureSpawn
-import kotlin.contracts.Effect
 
 external interface Constant<T>
 

--- a/src/main/kotlin/screeps/api/Constants.kt
+++ b/src/main/kotlin/screeps/api/Constants.kt
@@ -4,6 +4,7 @@ package screeps.api
 
 import screeps.api.structures.Structure
 import screeps.api.structures.StructureSpawn
+import kotlin.contracts.Effect
 
 external interface Constant<T>
 
@@ -12,6 +13,8 @@ inline val <T> Constant<T>.value: T get() = this.asDynamic().unsafeCast<T>()
 typealias StringConstant = Constant<String>
 typealias IntConstant = Constant<Int>
 
+external interface EffectConstant : IntConstant
+external interface PowerEffectConstant : EffectConstant
 external interface FindConstant<T> : IntConstant
 external interface ExitConstant : FindConstant<RoomPosition>
 external interface ScreepsReturnCode : IntConstant
@@ -23,7 +26,9 @@ external interface LookConstant<T> : StringConstant
 external interface DirectionConstant : IntConstant
 external interface TradableConstant : StringConstant
 external interface ResourceConstant : TradableConstant
+external interface CompressedResourceConstant : ResourceConstant
 external interface MineralConstant : ResourceConstant
+external interface DepositResourceConstant : ResourceConstant
 external interface ColorConstant : IntConstant
 external interface DensityConstant : IntConstant
 external interface OrderConstant : StringConstant
@@ -56,7 +61,6 @@ external val FIND_MY_CREEPS: FindConstant<Creep>
 external val FIND_HOSTILE_CREEPS: FindConstant<Creep>
 external val FIND_SOURCES_ACTIVE: FindConstant<Source>
 external val FIND_SOURCES: FindConstant<Source>
-external val FIND_DROPPED_ENERGY: FindConstant<Resource>
 external val FIND_DROPPED_RESOURCES: FindConstant<Resource>
 external val FIND_STRUCTURES: FindConstant<Structure>
 external val FIND_MY_STRUCTURES: FindConstant<Structure>
@@ -73,6 +77,8 @@ external val FIND_TOMBSTONES: FindConstant<Tombstone>
 external val FIND_POWER_CREEPS: FindConstant<PowerCreep>
 external val FIND_MY_POWER_CREEPS: FindConstant<PowerCreep>
 external val FIND_HOSTILE_POWER_CREEPS: FindConstant<PowerCreep>
+external val FIND_DEPOSITS: FindConstant<Deposit>
+external val FIND_RUINS: FindConstant<Ruin>
 
 external val TOP: DirectionConstant
 external val TOP_RIGHT: DirectionConstant
@@ -109,6 +115,8 @@ external val STRUCTURE_OBSERVER: BuildableStructureConstant
 external val STRUCTURE_POWER_BANK: StructureConstant
 external val STRUCTURE_POWER_SPAWN: BuildableStructureConstant
 external val STRUCTURE_EXTRACTOR: BuildableStructureConstant
+external val STRUCTURE_FACTORY: BuildableStructureConstant
+external val STRUCTURE_INVADER_CORE: StructureConstant
 external val STRUCTURE_LAB: BuildableStructureConstant
 external val STRUCTURE_TERMINAL: BuildableStructureConstant
 external val STRUCTURE_CONTAINER: BuildableStructureConstant
@@ -127,6 +135,11 @@ external val RESOURCE_ZYNTHIUM: MineralConstant
 external val RESOURCE_OXYGEN: MineralConstant
 external val RESOURCE_HYDROGEN: MineralConstant
 external val RESOURCE_CATALYST: MineralConstant
+
+external val RESOURCE_SILICON: DepositResourceConstant
+external val RESOURCE_METAL: DepositResourceConstant
+external val RESOURCE_BIOMASS: DepositResourceConstant
+external val RESOURCE_MIST: DepositResourceConstant
 
 external val RESOURCE_HYDROXIDE: ResourceConstant
 external val RESOURCE_ZYNTHIUM_KEANITE: ResourceConstant
@@ -164,17 +177,73 @@ external val RESOURCE_CATALYZED_GHODIUM_ALKALIDE: ResourceConstant
 
 external val RESOURCE_OPS: ResourceConstant
 
+external val RESOURCE_UTRIUM_BAR: CompressedResourceConstant
+external val RESOURCE_LEMERGIUM_BAR: CompressedResourceConstant
+external val RESOURCE_ZYNTHIUM_BAR: CompressedResourceConstant
+external val RESOURCE_KEANIUM_BAR: CompressedResourceConstant
+external val RESOURCE_GHODIUM_MELT: CompressedResourceConstant
+external val RESOURCE_OXIDANT: CompressedResourceConstant
+external val RESOURCE_REDUCTANT: CompressedResourceConstant
+external val RESOURCE_PURIFIER: CompressedResourceConstant
+external val RESOURCE_BATTERY: CompressedResourceConstant
+
+external val RESOURCE_COMPOSITE: ResourceConstant
+external val RESOURCE_CRYSTAL: ResourceConstant
+external val RESOURCE_LIQUID: ResourceConstant
+
+external val RESOURCE_WIRE: ResourceConstant
+external val RESOURCE_SWITCH: ResourceConstant
+external val RESOURCE_TRANSISTOR: ResourceConstant
+external val RESOURCE_MICROCHIP: ResourceConstant
+external val RESOURCE_CIRCUIT: ResourceConstant
+external val RESOURCE_DEVICE: ResourceConstant
+
+external val RESOURCE_CELL: ResourceConstant
+external val RESOURCE_PHLEGM: ResourceConstant
+external val RESOURCE_TISSUE: ResourceConstant
+external val RESOURCE_MUSCLE: ResourceConstant
+external val RESOURCE_ORGANOID: ResourceConstant
+external val RESOURCE_ORGANISM: ResourceConstant
+
+external val RESOURCE_ALLOY: ResourceConstant
+external val RESOURCE_TUBE: ResourceConstant
+external val RESOURCE_FIXTURES: ResourceConstant
+external val RESOURCE_FRAME: ResourceConstant
+external val RESOURCE_HYDRAULICS: ResourceConstant
+external val RESOURCE_MACHINE: ResourceConstant
+
+external val RESOURCE_CONDENSATE: ResourceConstant
+external val RESOURCE_CONCENTRATE: ResourceConstant
+external val RESOURCE_EXTRACT: ResourceConstant
+external val RESOURCE_SPIRIT: ResourceConstant
+external val RESOURCE_EMANATION: ResourceConstant
+external val RESOURCE_ESSENCE: ResourceConstant
+
+external interface CommodityRecipe {
+    val level: Int?
+    val amount: Int
+    val cooldown: Int
+    val components: Record<ResourceConstant, Int>
+}
+
+external val COMMODITIES: Record<ResourceConstant, CommodityRecipe>
+
+external val REACTIONS: Record<ResourceConstant, Record<ResourceConstant, ResourceConstant>>
+external val REACTION_TIME: Record<ResourceConstant, Int>
+
 external val LOOK_CREEPS: LookConstant<Creep>
 external val LOOK_ENERGY: LookConstant<Resource>
 external val LOOK_RESOURCES: LookConstant<Resource>
 external val LOOK_SOURCES: LookConstant<Source>
 external val LOOK_MINERALS: LookConstant<Mineral>
+external val LOOK_DEPOSITS: LookConstant<Deposit>
 external val LOOK_STRUCTURES: LookConstant<Structure>
 external val LOOK_FLAGS: LookConstant<Flag>
 external val LOOK_CONSTRUCTION_SITES: LookConstant<ConstructionSite>
 external val LOOK_NUKES: LookConstant<Nuke>
 external val LOOK_TERRAIN: LookConstant<TerrainConstant>
 external val LOOK_TOMBSTONES: LookConstant<Tombstone>
+external val LOOK_RUINS: LookConstant<Ruin>
 
 external val WORK: ActiveBodyPartConstant
 external val CARRY: ActiveBodyPartConstant
@@ -210,9 +279,11 @@ external val LINK_LOSS_RATIO: Double
 external val STORAGE_CAPACITY: Int
 external val STORAGE_HITS: Int
 external val BODYPARTS_ALL: Array<BodyPartConstant>
+external val RESOURCES_ALL: Array<ResourceConstant>
 external val CARRY_CAPACITY: Int
 external val HARVEST_POWER: Int
 external val HARVEST_MINERAL_POWER: Int
+external val HARVEST_DEPOSIT_POWER: Int
 external val REPAIR_POWER: Int
 external val DISMANTLE_POWER: Int
 external val BUILD_POWER: Int
@@ -250,6 +321,15 @@ external val NUKE_LAND_TIME: Int
 external val NUKE_RANGE: Int
 external val NUKE_DAMAGE: Record<Int, Int>
 
+external val FACTORY_HITS: Int
+external val FACTORY_CAPACITY: Int
+
+external val TOMBSTONE_DECAY_PER_PART: Int
+external val TOMBSTONE_DECAY_POWER_CREEP: Int
+
+external val RUIN_DECAY: Int
+external val RUIN_DECAY_STRUCTURES: Record<StructureConstant, Int>
+
 external val CONTROLLER_LEVELS: Record<Int, Int>
 external val CONTROLLER_STRUCTURES: Record<StructureConstant, Record<Int, Int>>
 external val CONTROLLER_DOWNGRADE: Record<Int, Int>
@@ -284,6 +364,14 @@ external val POWER_SPAWN_ENERGY_RATIO: Int
 
 external val ORDER_SELL: OrderConstant
 external val ORDER_BUY: OrderConstant
+
+external val MARKET_FEE: Number
+
+external val MARKET_MAX_ORDERS: Int
+external val MARKET_ORDER_LIFE_TIME: Int
+
+external val FLAGS_LIMIT: Int
+
 external val SUBSCRIPTION_TOKEN: TradableConstant
 
 // Kotlin specific constants - used to indicate a subset of a type
@@ -315,7 +403,6 @@ val ALGORITHM_DIJKSTRA: AlgorithmConstant = "dijkstra".unsafeCast<AlgorithmConst
 
 
 external interface PowerClassConstant : StringConstant
-external interface PowerEffectConstant : IntConstant
 
 external interface PowerClass {
     val OPERATOR: PowerClassConstant
@@ -348,3 +435,14 @@ external val PWR_OPERATE_POWER: PowerEffectConstant
 external val PWR_FORTIFY: PowerEffectConstant
 external val PWR_OPERATE_CONTROLLER: PowerEffectConstant
 external val PWR_OPERATE_FACTORY: PowerEffectConstant
+
+external val EFFECT_INVULNERABILITY: EffectConstant
+external val EFFECT_COLLAPSE_TIMER: EffectConstant
+
+external val INVADER_CORE_HITS: Int
+external val INVADER_CORE_CREEP_SPAWN_TIME: Record<Int, Int>
+external val INVADER_CORE_EXPAND_TIME: Record<Int, Int>
+external val INVADER_CORE_CONTROLLER_POWER: Int
+external val INVADER_CORE_CONTROLLER_DOWNGRADE: Int
+external val STRONGHOLD_RAMPART_HITS: Record<Int, Int>
+external val STRONGHOLD_DECAY_TICKS: Int

--- a/src/main/kotlin/screeps/api/Deposit.kt
+++ b/src/main/kotlin/screeps/api/Deposit.kt
@@ -1,0 +1,5 @@
+package screeps.api
+
+abstract external class Deposit : RoomObjectNotNull, Decaying, Harvestable, Identifiable {
+    val lastCooldown: Int
+}

--- a/src/main/kotlin/screeps/api/GenericCreep.kt
+++ b/src/main/kotlin/screeps/api/GenericCreep.kt
@@ -1,8 +1,6 @@
 package screeps.api
 
-external interface GenericCreep : RoomObjectNotNull, Owned, Attackable, Identifiable {
-    val carry: StoreDefinition
-    val carryCapacity: Int
+external interface GenericCreep : RoomObjectNotNull, Owned, Attackable, Identifiable, IStore {
     val memory: MemoryMarker
     val name: String
     val saying: String

--- a/src/main/kotlin/screeps/api/GenericCreep.kt
+++ b/src/main/kotlin/screeps/api/GenericCreep.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-external interface GenericCreep : RoomObjectNotNull, Owned, Attackable, Identifiable, IStore {
+external interface GenericCreep : RoomObjectNotNull, Owned, Attackable, Identifiable, StoreOwner {
     val memory: MemoryMarker
     val name: String
     val saying: String

--- a/src/main/kotlin/screeps/api/Market.kt
+++ b/src/main/kotlin/screeps/api/Market.kt
@@ -1,5 +1,7 @@
 package screeps.api
 
+import kotlin.js.Date
+
 external interface Market {
     val credits: Double
     val incomingTransactions: Array<Transaction>
@@ -9,18 +11,18 @@ external interface Market {
     fun calcTransactionCost(amount: Int, roomName1: String, roomName2: String): Int
     fun cancelOrder(orderId: String): ScreepsReturnCode
     fun changeOrderPrice(orderId: String, newPrice: Double): ScreepsReturnCode
-    fun createOrder(
-        type: OrderConstant,
-        resourceType: TradableConstant,
-        price: Double,
-        totalAmount: Int,
-        roomName: String = definedExternally
-    ): ScreepsReturnCode
+    fun createOrder(params: Order.CreationParams = definedExternally): ScreepsReturnCode
 
     fun deal(orderId: String, amount: Int, targetRoomName: String = definedExternally): ScreepsReturnCode
     fun extendOrder(orderId: String, addAmount: Int): ScreepsReturnCode
     fun getAllOrders(filter: Order.Filter = definedExternally): Array<Order>
     fun getAllOrders(filter: ((o: Order) -> Boolean) = definedExternally): Array<Order>
+
+    /**
+     * Get daily price history of the specified resource on the market for the last 14 days
+     */
+    fun getHistory(resourceType: TradableConstant?): Array<HistoryEntry>
+
     fun getAllOrders(): Array<Order>
     fun getOrderById(id: String): Order?
 
@@ -46,6 +48,14 @@ external interface Market {
             var remainingAmount: Int?
             var price: Double?
         }
+
+        interface CreationParams {
+            var type: OrderConstant
+            var resourceType: TradableConstant
+            var price: Double
+            var totalAmount: Int
+            var roomName: String?
+        }
     }
 
     interface Transaction {
@@ -65,5 +75,14 @@ external interface Market {
             val type: OrderConstant
             val price: Double
         }
+    }
+
+    interface HistoryEntry {
+        val resourceType: ResourceConstant
+        val date: Date
+        val transactions: Int
+        val volume: Int
+        val avgPrice: Float
+        val stddevPrice: Float
     }
 }

--- a/src/main/kotlin/screeps/api/Mineral.kt
+++ b/src/main/kotlin/screeps/api/Mineral.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-abstract external class Mineral : RoomObjectNotNull, Harvestable, Identifiable {
+abstract external class Mineral : RoomObjectNotNull, RenewableHarvestable, Identifiable {
     val density: DensityConstant
     val mineralAmount: Int
     val mineralType: MineralConstant

--- a/src/main/kotlin/screeps/api/RoomObject.kt
+++ b/src/main/kotlin/screeps/api/RoomObject.kt
@@ -9,7 +9,7 @@ external interface RoomObject : HasPosition {
     val effects: Array<RoomEffect>?
 
     interface RoomEffect {
-        val power: PowerEffectConstant
+        val effect: EffectConstant
         val level: Int
         val ticksRemaining: Int
     }

--- a/src/main/kotlin/screeps/api/Ruin.kt
+++ b/src/main/kotlin/screeps/api/Ruin.kt
@@ -1,0 +1,6 @@
+package screeps.api
+
+abstract external class Ruin : RoomObjectNotNull, Decaying, Identifiable, IStore {
+    val creep: Creep
+    val deathTime: Int
+}

--- a/src/main/kotlin/screeps/api/Ruin.kt
+++ b/src/main/kotlin/screeps/api/Ruin.kt
@@ -1,6 +1,8 @@
 package screeps.api
 
-abstract external class Ruin : RoomObjectNotNull, Decaying, Identifiable, IStore {
-    val creep: Creep
-    val deathTime: Int
+import screeps.api.structures.Structure
+
+abstract external class Ruin : RoomObjectNotNull, Decaying, Identifiable, StoreOwner {
+    val structure: Structure
+    val destroyTime: Int
 }

--- a/src/main/kotlin/screeps/api/Source.kt
+++ b/src/main/kotlin/screeps/api/Source.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-abstract external class Source : RoomObjectNotNull, Harvestable, Identifiable {
+abstract external class Source : RoomObjectNotNull, RenewableHarvestable, Identifiable {
     val energy: Int
     val energyCapacity: Int
 }

--- a/src/main/kotlin/screeps/api/Store.kt
+++ b/src/main/kotlin/screeps/api/Store.kt
@@ -1,6 +1,6 @@
 package screeps.api
 
-external interface StoreDefinition : Record<ResourceConstant, Int> {
+external interface Store : Record<ResourceConstant, Int> {
     /**
      * Returns total store capacity
      */

--- a/src/main/kotlin/screeps/api/StoreDefinition.kt
+++ b/src/main/kotlin/screeps/api/StoreDefinition.kt
@@ -1,5 +1,31 @@
 package screeps.api
 
 external interface StoreDefinition : Record<ResourceConstant, Int> {
-    val energy: Int
+    /**
+     * Returns total store capacity
+     */
+    fun getCapacity(): Int
+
+    /**
+     * Returns capacity number, or null in case of a not valid resource for this store type of this store
+     * for the specified resource
+     */
+    fun getCapacity(resource: ResourceConstant): Int?
+
+    /**
+     * A shorthand for getCapacity(resource) - getUsedCapacity(resource)
+     */
+    fun getFreeCapacity(): Int
+    fun getFreeCapacity(resource: ResourceConstant): Int?
+
+    /**
+     * Returns total used capacity for general purpose stores
+     */
+    fun getUsedCapacity(): Int
+    /**
+     * Returns the capacity used by the specified resource, or null in case of a not valid resource
+     * for this store type
+     */
+    fun getUsedCapacity(resource: ResourceConstant): Int?
+
 }

--- a/src/main/kotlin/screeps/api/Tombstone.kt
+++ b/src/main/kotlin/screeps/api/Tombstone.kt
@@ -1,8 +1,6 @@
 package screeps.api
 
-import screeps.api.structures.Structure
-
-abstract external class Tombstone : RoomObjectNotNull, Decaying, Identifiable, IStore {
-    val structure: Structure
-    val destroyTime: Int
+abstract external class Tombstone : RoomObjectNotNull, Decaying, Identifiable, StoreOwner {
+    val creep: Creep
+    val deathTime: Int
 }

--- a/src/main/kotlin/screeps/api/Tombstone.kt
+++ b/src/main/kotlin/screeps/api/Tombstone.kt
@@ -1,7 +1,8 @@
 package screeps.api
 
-abstract external class Tombstone : RoomObjectNotNull, Decaying, Identifiable {
-    val creep: Creep
-    val deathTime: Int
-    val store: StoreDefinition
+import screeps.api.structures.Structure
+
+abstract external class Tombstone : RoomObjectNotNull, Decaying, Identifiable, IStore {
+    val structure: Structure
+    val destroyTime: Int
 }

--- a/src/main/kotlin/screeps/api/Traits.kt
+++ b/src/main/kotlin/screeps/api/Traits.kt
@@ -49,6 +49,6 @@ external interface IStructure : RoomObjectNotNull, Attackable, Identifiable, Own
     fun notifyWhenAttacked(enabled: Boolean): ScreepsReturnCode
 }
 
-external interface IStore {
-    val store: StoreDefinition
+external interface StoreOwner {
+    val store: Store
 }

--- a/src/main/kotlin/screeps/api/Traits.kt
+++ b/src/main/kotlin/screeps/api/Traits.kt
@@ -4,8 +4,14 @@ external interface Identifiable {
     val id: String
 }
 
-external interface Harvestable {
+external interface Harvestable
+
+external interface RenewableHarvestable : Harvestable {
     val ticksToRegeneration: Int
+}
+
+external interface WithCooldown {
+    val cooldown: Int
 }
 
 external interface Decaying {
@@ -43,12 +49,6 @@ external interface IStructure : RoomObjectNotNull, Attackable, Identifiable, Own
     fun notifyWhenAttacked(enabled: Boolean): ScreepsReturnCode
 }
 
-external interface EnergyContainer : IStructure, Owned {
-    val energy: Int
-    val energyCapacity: Int
-}
-
-external interface Store : IStructure, Owned {
+external interface IStore {
     val store: StoreDefinition
-    val storeCapacity: Int
 }

--- a/src/main/kotlin/screeps/api/structures/StructureContainer.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureContainer.kt
@@ -1,7 +1,6 @@
 package screeps.api.structures
 
 import screeps.api.Decaying
-import screeps.api.Store
-import screeps.api.StoreDefinition
+import screeps.api.IStore
 
-abstract external class StructureContainer : Structure, Decaying, Store
+abstract external class StructureContainer : Structure, Decaying, IStore

--- a/src/main/kotlin/screeps/api/structures/StructureContainer.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureContainer.kt
@@ -1,6 +1,6 @@
 package screeps.api.structures
 
 import screeps.api.Decaying
-import screeps.api.IStore
+import screeps.api.StoreOwner
 
-abstract external class StructureContainer : Structure, Decaying, IStore
+abstract external class StructureContainer : Structure, Decaying, StoreOwner

--- a/src/main/kotlin/screeps/api/structures/StructureExtension.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureExtension.kt
@@ -1,6 +1,6 @@
 package screeps.api.structures
 
-import screeps.api.IStore
+import screeps.api.StoreOwner
 import screeps.api.Owned
 
-abstract external class StructureExtension : Structure, Owned, IStore
+abstract external class StructureExtension : Structure, Owned, StoreOwner

--- a/src/main/kotlin/screeps/api/structures/StructureExtension.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureExtension.kt
@@ -1,6 +1,6 @@
 package screeps.api.structures
 
-import screeps.api.EnergyContainer
+import screeps.api.IStore
 import screeps.api.Owned
 
-abstract external class StructureExtension : Structure, Owned, EnergyContainer
+abstract external class StructureExtension : Structure, Owned, IStore

--- a/src/main/kotlin/screeps/api/structures/StructureExtractor.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureExtractor.kt
@@ -1,7 +1,6 @@
 package screeps.api.structures
 
 import screeps.api.Owned
+import screeps.api.WithCooldown
 
-abstract external class StructureExtractor : Structure, Owned {
-    val cooldown: Int
-}
+abstract external class StructureExtractor : Structure, Owned, WithCooldown

--- a/src/main/kotlin/screeps/api/structures/StructureFactory.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureFactory.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureFactory : Structure, Owned, IStore, WithCooldown {
+abstract external class StructureFactory : Structure, Owned, StoreOwner, WithCooldown {
     val level: Int
 
     /**

--- a/src/main/kotlin/screeps/api/structures/StructureFactory.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureFactory.kt
@@ -1,0 +1,13 @@
+package screeps.api.structures
+
+import screeps.api.*
+
+abstract external class StructureFactory : Structure, Owned, IStore, WithCooldown {
+    val level: Int
+
+    /**
+     * Produces the specified commodity. All ingredients should be available in the factory store
+     */
+    fun produce(resource: ResourceConstant): ScreepsReturnCode
+
+}

--- a/src/main/kotlin/screeps/api/structures/StructureInvaderCore.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureInvaderCore.kt
@@ -1,0 +1,8 @@
+package screeps.api.structures
+
+import screeps.api.Owned
+
+abstract external class StructureInvaderCore : Structure, Owned {
+    val level: Int
+    val ticksToDeploy: Int
+}

--- a/src/main/kotlin/screeps/api/structures/StructureLab.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureLab.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureLab : Structure, Owned, IStore, WithCooldown {
+abstract external class StructureLab : Structure, Owned, StoreOwner, WithCooldown {
     fun boostCreep(creep: Creep, bodyPartsCount: Int = definedExternally): ScreepsReturnCode
     fun runReaction(lab1: StructureLab, lab2: StructureLab): ScreepsReturnCode
     fun unboostCreep(creep: Creep): ScreepsReturnCode

--- a/src/main/kotlin/screeps/api/structures/StructureLab.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureLab.kt
@@ -2,11 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureLab : Structure, Owned, EnergyContainer {
-    val cooldown: Int
-    val mineralAmount: Int
-    val mineralType: ResourceConstant
-    val mineralCapacity: Int
+abstract external class StructureLab : Structure, Owned, IStore, WithCooldown {
     fun boostCreep(creep: Creep, bodyPartsCount: Int = definedExternally): ScreepsReturnCode
     fun runReaction(lab1: StructureLab, lab2: StructureLab): ScreepsReturnCode
     fun unboostCreep(creep: Creep): ScreepsReturnCode

--- a/src/main/kotlin/screeps/api/structures/StructureLink.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureLink.kt
@@ -1,10 +1,10 @@
 package screeps.api.structures
 
-import screeps.api.EnergyContainer
 import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
+import screeps.api.IStore
+import screeps.api.WithCooldown
 
-abstract external class StructureLink : Structure, Owned, EnergyContainer {
-    val cooldown: Int
+abstract external class StructureLink : Structure, Owned, IStore, WithCooldown {
     fun transferEnergy(target: StructureLink, amount: Int = definedExternally): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/structures/StructureLink.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureLink.kt
@@ -2,9 +2,9 @@ package screeps.api.structures
 
 import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
-import screeps.api.IStore
+import screeps.api.StoreOwner
 import screeps.api.WithCooldown
 
-abstract external class StructureLink : Structure, Owned, IStore, WithCooldown {
+abstract external class StructureLink : Structure, Owned, StoreOwner, WithCooldown {
     fun transferEnergy(target: StructureLink, amount: Int = definedExternally): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/structures/StructureNuker.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureNuker.kt
@@ -1,13 +1,7 @@
 package screeps.api.structures
 
-import screeps.api.EnergyContainer
-import screeps.api.Owned
-import screeps.api.RoomPosition
-import screeps.api.ScreepsReturnCode
+import screeps.api.*
 
-abstract external class StructureNuker : Structure, Owned, EnergyContainer {
-    val ghodium: Int
-    val ghodiumCapacity: Int
-    val coolDown: Int
+abstract external class StructureNuker : Structure, Owned, IStore, WithCooldown {
     fun launchNuke(position: RoomPosition): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/structures/StructureNuker.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureNuker.kt
@@ -2,6 +2,6 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureNuker : Structure, Owned, IStore, WithCooldown {
+abstract external class StructureNuker : Structure, Owned, StoreOwner, WithCooldown {
     fun launchNuke(position: RoomPosition): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/structures/StructurePowerSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructurePowerSpawn.kt
@@ -1,12 +1,10 @@
 package screeps.api.structures
 
-import screeps.api.EnergyContainer
 import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
+import screeps.api.IStore
 
-abstract external class StructurePowerSpawn : Structure, Owned, EnergyContainer {
-    val power: Int
-    val powerCapacity: Int
+abstract external class StructurePowerSpawn : Structure, Owned, IStore {
     fun createPowerCreep(name: String): ScreepsReturnCode
     fun processPower(): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/structures/StructurePowerSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructurePowerSpawn.kt
@@ -2,9 +2,9 @@ package screeps.api.structures
 
 import screeps.api.Owned
 import screeps.api.ScreepsReturnCode
-import screeps.api.IStore
+import screeps.api.StoreOwner
 
-abstract external class StructurePowerSpawn : Structure, Owned, IStore {
+abstract external class StructurePowerSpawn : Structure, Owned, StoreOwner {
     fun createPowerCreep(name: String): ScreepsReturnCode
     fun processPower(): ScreepsReturnCode
 }

--- a/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureSpawn : Structure, Owned, EnergyContainer {
+abstract external class StructureSpawn : Structure, Owned, IStore {
     val memory: SpawnMemory
     val name: String
     val spawning: Spawning?
@@ -50,7 +50,7 @@ abstract external class StructureSpawn : Structure, Owned, EnergyContainer {
 
 external interface SpawnOptions : Options {
     var memory: CreepMemory?
-    var energyStructures: Array<EnergyContainer>?
+    var energyStructures: Array<IStore>?
     var dryRun: Boolean?
     var directions: Array<DirectionConstant>?
 }

--- a/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureSpawn.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureSpawn : Structure, Owned, IStore {
+abstract external class StructureSpawn : Structure, Owned, StoreOwner {
     val memory: SpawnMemory
     val name: String
     val spawning: Spawning?
@@ -50,7 +50,7 @@ abstract external class StructureSpawn : Structure, Owned, IStore {
 
 external interface SpawnOptions : Options {
     var memory: CreepMemory?
-    var energyStructures: Array<IStore>?
+    var energyStructures: Array<StoreOwner>?
     var dryRun: Boolean?
     var directions: Array<DirectionConstant>?
 }

--- a/src/main/kotlin/screeps/api/structures/StructureStorage.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureStorage.kt
@@ -1,7 +1,6 @@
 package screeps.api.structures
 
 import screeps.api.Owned
-import screeps.api.Store
-import screeps.api.StoreDefinition
+import screeps.api.IStore
 
-abstract external class StructureStorage : Structure, Owned, Store
+abstract external class StructureStorage : Structure, Owned, IStore

--- a/src/main/kotlin/screeps/api/structures/StructureStorage.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureStorage.kt
@@ -1,6 +1,6 @@
 package screeps.api.structures
 
 import screeps.api.Owned
-import screeps.api.IStore
+import screeps.api.StoreOwner
 
-abstract external class StructureStorage : Structure, Owned, IStore
+abstract external class StructureStorage : Structure, Owned, StoreOwner

--- a/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureTerminal : Structure, Owned, IStore, WithCooldown {
+abstract external class StructureTerminal : Structure, Owned, StoreOwner, WithCooldown {
     fun send(
         resourceType: ResourceConstant,
         amount: Int,

--- a/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureTerminal.kt
@@ -2,8 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureTerminal : Structure, Owned, Store {
-    val cooldown: Int
+abstract external class StructureTerminal : Structure, Owned, IStore, WithCooldown {
     fun send(
         resourceType: ResourceConstant,
         amount: Int,

--- a/src/main/kotlin/screeps/api/structures/StructureTower.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureTower.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureTower : Structure, Owned, EnergyContainer {
+abstract external class StructureTower : Structure, Owned, IStore {
     fun attack(target: Creep): ScreepsReturnCode
     fun heal(target: Creep): ScreepsReturnCode
     fun repair(target: IStructure): ScreepsReturnCode

--- a/src/main/kotlin/screeps/api/structures/StructureTower.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureTower.kt
@@ -2,7 +2,7 @@ package screeps.api.structures
 
 import screeps.api.*
 
-abstract external class StructureTower : Structure, Owned, IStore {
+abstract external class StructureTower : Structure, Owned, StoreOwner {
     fun attack(target: Creep): ScreepsReturnCode
     fun heal(target: Creep): ScreepsReturnCode
     fun repair(target: IStructure): ScreepsReturnCode


### PR DESCRIPTION
- Added new update constants and new entities support
- Removed EnergyContainer interface. Improved Store interface instead.
- Minor structural improvements

New Store interface has some interesting features.
For now all entities, which had energy, power or any other resource in their entity variable, implement Store instead.

If getCapacity(), getFreeCapacity(), getUsedCapacity() is called by entity which can contain any resource (creep, Storage, Terminal, Container) - overall capacity will be returned.
**But**!!  getCapacity() and other methods which would be called by for example Link or Spawn will return null, because you need to set the exact ResourceConstant _(getCapacity(RESOURCE_ENERGY))_ for getting max capacity for that resource

Assuming that I'd be glad if someone improve Store interface for all possible variants of usage