### PR TITLE
Make StoreOwner extend Identifiable

### DIFF
--- a/src/main/kotlin/screeps/api/Traits.kt
+++ b/src/main/kotlin/screeps/api/Traits.kt
@@ -49,6 +49,6 @@ external interface IStructure : RoomObjectNotNull, Attackable, Identifiable, Own
     fun notifyWhenAttacked(enabled: Boolean): ScreepsReturnCode
 }
 
-external interface StoreOwner : Identifiable {
+external interface StoreOwner : Identifiable, HasPosition {
     val store: Store
 }

--- a/src/main/kotlin/screeps/api/Traits.kt
+++ b/src/main/kotlin/screeps/api/Traits.kt
@@ -49,6 +49,6 @@ external interface IStructure : RoomObjectNotNull, Attackable, Identifiable, Own
     fun notifyWhenAttacked(enabled: Boolean): ScreepsReturnCode
 }
 
-external interface StoreOwner {
+external interface StoreOwner : Identifiable {
     val store: Store
 }


### PR DESCRIPTION
All these have an `id`

https://docs.screeps.com/api/#Creep
https://docs.screeps.com/api/#PowerCreep
https://docs.screeps.com/api/#Ruin
https://docs.screeps.com/api/#Structure
https://docs.screeps.com/api/#Tombstone