### PR TITLE
Update Store.kt

### DIFF
--- a/src/main/kotlin/screeps/api/Store.kt
+++ b/src/main/kotlin/screeps/api/Store.kt
@@ -4,7 +4,7 @@ external interface Store : Record<ResourceConstant, Int> {
     /**
      * Returns total store capacity
      */
-    fun getCapacity(): Int
+    fun getCapacity(): Int?
 
     /**
      * Returns capacity number, or null in case of a not valid resource for this store type of this store


### PR DESCRIPTION
`getCapacity` returns `null` when used on a structure.

```
        val targets = toRoom.find(FIND_MY_STRUCTURES)
            .filter { (it.structureType == STRUCTURE_EXTENSION || it.structureType == STRUCTURE_SPAWN) }

        targets.map {
            console.log(it.structureType)
            console.log(it.unsafeCast<StoreOwner>().store[RESOURCE_ENERGY])
            console.log(it.unsafeCast<StoreOwner>().store.getCapacity())
        }
```


[01:41:28]spawn
[01:41:28]300
[01:41:28]null
[01:41:28]extension
[01:41:28]50
[01:41:28]null
[01:41:28]extension
[01:41:28]50
[01:41:28]null
[01:41:28]extension
[01:41:28]50
[01:41:28]null
