### PR TITLE
Apparently the ticksToSpawn value is null when the SourceKeepers are …

### DIFF
--- a/src/main/kotlin/screeps/api/structures/StructureKeeperLair.kt
+++ b/src/main/kotlin/screeps/api/structures/StructureKeeperLair.kt
@@ -3,5 +3,5 @@ package screeps.api.structures
 import screeps.api.Owned
 
 abstract external class StructureKeeperLair : Structure, Owned {
-    val ticksToSpawn: Int
+    val ticksToSpawn: Int?
 }


### PR DESCRIPTION
…spawned and undamaged (contrary to the API)