### PR TITLE
Fix type requirement for findClosestByPath with FIND_*

### DIFF
--- a/src/main/kotlin/screeps/api/RoomPosition.kt
+++ b/src/main/kotlin/screeps/api/RoomPosition.kt
@@ -20,7 +20,7 @@ external class RoomPosition(x: Int, y: Int, roomName: String) : NavigationTarget
         opts: FindClosestByPathOptions<T> = definedExternally
     ): T?
 
-    fun <T : RoomObject> findClosestByPath(
+    fun <T> findClosestByPath(
         type: FindConstant<T>,
         opts: FindClosestByPathOptions<T> = definedExternally
     ): T?


### PR DESCRIPTION
Can't really dictate the return be a `RoomObject`. 
As https://docs.screeps.com/api/#Room.find shows, there are many different return types.

This is also in line with `Room.find()` which is defined as `fun <T> find(findConstant: FindConstant<T>, opts: FilterOption<T> = definedExternally): Array<T>` 

