### PR TITLE
Updated to Kotlin 1.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.jfrog.bintray.gradle.BintrayExtension
+import com.jfrog.bintray.gradle.tasks.BintrayUploadTask
+import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact
 
 plugins {
     kotlin("js") version "1.4.0"
@@ -38,6 +40,21 @@ publishing {
 
 val bintrayUser: String? by project
 val bintrayApiKey: String? by project
+
+tasks.withType<BintrayUploadTask> {
+    doFirst {
+        publishing.publications
+            .filterIsInstance<MavenPublication>()
+            .forEach { publication ->
+                val moduleFile = buildDir.resolve("publications/${publication.name}/module.json")
+                if (moduleFile.exists()) {
+                    publication.artifact(object : FileBasedMavenArtifact(moduleFile) {
+                        override fun getDefaultExtension() = "module"
+                    })
+                }
+            }
+    }
+}
 
 bintray {
     user = bintrayUser ?: ""

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.jfrog.bintray.gradle.tasks.BintrayUploadTask
 import org.gradle.api.publish.maven.internal.artifact.FileBasedMavenArtifact
 
 plugins {
-    kotlin("js") version "1.4.0"
+    kotlin("js") version "1.4.10"
     `maven-publish`
     id("com.jfrog.bintray") version "1.8.5"
 }
@@ -28,11 +28,8 @@ kotlin {
 
 publishing {
     publications {
-        create<MavenPublication>("kotlin") {
+        register<MavenPublication>("kotlin") {
             from(components["kotlin"])
-            groupId = project.group.toString()
-            artifactId = project.name
-
             artifact(tasks.getByName<Zip>("jsLegacySourcesJar"))
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 import com.jfrog.bintray.gradle.BintrayExtension
 
 plugins {
-    kotlin("js") version "1.3.71"
+    kotlin("js") version "1.4.0"
     `maven-publish`
-    id("com.jfrog.bintray") version "1.8.1"
+    id("com.jfrog.bintray") version "1.8.5"
 }
 
 repositories {
@@ -11,27 +11,27 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-js"))
     testImplementation(kotlin("test-js"))
 }
 
 group = "ch.delconte.screeps-kotlin"
 
 kotlin {
-    target {
+    js(BOTH) {
         useCommonJs()
         nodejs()
     }
 }
 
 
-val kotlinSourcesJar by tasks
-
 publishing {
     publications {
-        register("kotlin", MavenPublication::class) {
+        create<MavenPublication>("kotlin") {
             from(components["kotlin"])
-            artifact(kotlinSourcesJar)
+            groupId = project.group.toString()
+            artifactId = project.name
+
+            artifact(tasks.getByName<Zip>("jsLegacySourcesJar"))
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
In theory this branch should update the compiler to version 1.4 in IR and Legacy mode as well as publish the artifact correctly back to bintray (but I don't know if it really works). I used [kotlinx-nodejs](https://github.com/Kotlin/kotlinx-nodejs/blob/master/kotlinx-nodejs/build.gradle.kts) as a sample for the bintray upload part.

All tests are at least passing with kotlin 1.4