### PR TITLE
Testing locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,5 @@
 out/
 build/
 
-gradle.properties
-
 node_modules/
 package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,22 @@ To get started, just clone this repository, and install the required dependencie
 ./gradlew build
 ```
 
+## Testing Locally 
+
+Install the library locally
+
+* Run `./gradlew publishKotlinPublicationToMavenLocal` to install the library locally on your machine
+* Add `mavenLocal()` to the repositories section of your bots build.gradle.kts
+* Change the dependency in your bot to `ch.delconte.screeps-kotlin:screeps-kotlin-types:SNAPSHOT`
+
+OR
+
+Using https://jitpack.io/
+
+* Add `maven( url="https://jitpack.io")` to the repositories section of your bots build.gradle
+* Add the branch or last commit of your PR as a dependency to your bot implementation eg `com.github.<github_user>:screeps-kotlin-types:<branch_name>-SNAPSHOT")`
+
+
 ## Filing Issues
 
 Please feel free to submit issues for bugs and feature requests, I promise to get back to you ASAP!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ OR
 
 Using https://jitpack.io/
 
-* Add `maven( url="https://jitpack.io")` to the repositories section of your bots build.gradle
+* Add `maven( url="https://jitpack.io")` to the repositories section of your bots build.gradle.kts
 * Add the branch or last commit of your PR as a dependency to your bot implementation eg `com.github.<github_user>:screeps-kotlin-types:<branch_name>-SNAPSHOT")`
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version=SNAPSHOT


### PR DESCRIPTION
This PR is designed to make local testing slightly easier and to document the process. 

I added a gradle.properties file with `version=SNAPSHOT`. This is so as to avoid the step of altering the build.gradle.kts file to add a version when building locally. `./gradlew publishKotlinPublicationToMavenLocal` will now build and add a version as "SNAPSHOT" without any other changes required. 

No need, I think, to add a version number before SNAPSHOT here (I'd actually argue, ever, but there is a time and place for development philosophy ;)), and this avoids having to update this file on each release. 

I had to remove gradle.properties from .gitignore in order to add this file. I think it is fine (possibly recommended) to add this file to SCM, but I don't know if this will clash with anyone's local configuration. 

In order to release a named version `./gradlew -Pversion=<version> publish` can be used at the command line or from CI. 

I have added a section to CONTRIBUTING.md describing how to locally install and reference based on this procedure. 