### PR TITLE
Added operator modifiers

### DIFF
--- a/src/main/kotlin/screeps/api/PathFinder.kt
+++ b/src/main/kotlin/screeps/api/PathFinder.kt
@@ -7,8 +7,8 @@ external object PathFinder {
     fun search(origin: RoomPosition, goal: Array<GoalWithRange>, options: SearchOptions = definedExternally): Path
 
     class CostMatrix : screeps.api.CostMatrix {
-        fun set(x: Int, y: Int, cost: Int)
-        fun get(x: Int, y: Int): Int
+        operator fun set(x: Int, y: Int, cost: Int)
+        operator fun get(x: Int, y: Int): Int
         fun clone(): CostMatrix
         fun serialize(): Array<Int>
         var _bits: Array<Int>

--- a/src/main/kotlin/screeps/api/Room.kt
+++ b/src/main/kotlin/screeps/api/Room.kt
@@ -41,7 +41,7 @@ abstract external class Room {
 
     class Terrain(roomName: String) {
         val roomName: String
-        fun get(x: Int, y: Int): TerrainMaskConstant
+        operator fun get(x: Int, y: Int): TerrainMaskConstant
         fun getRawBuffer() : Array<Int>
     }
 


### PR DESCRIPTION
Added operator modifiers to Room.Terrain.get, CostMatrix.get and CostMatrix.set. 

This allows syntax like terrain[x, y], costMatrix[x, y] and costMatrix[x, y] = 5, rather than having to call the get and set methods explicitly. 