### PR TITLE
Add Room Events #83

### DIFF
--- a/src/jsMain/kotlin/screeps/api/Constants.kt
+++ b/src/jsMain/kotlin/screeps/api/Constants.kt
@@ -22,6 +22,9 @@ external interface ActiveBodyPartConstant : BodyPartConstant
 external interface StructureConstant : StringConstant
 external interface BuildableStructureConstant : StructureConstant
 external interface LookConstant<T> : StringConstant
+external interface EventConstant<T> : IntConstant
+external interface EventAttackTypeConstant : IntConstant
+external interface EventHealTypeConstant : IntConstant
 external interface DirectionConstant : IntConstant
 external interface TradableConstant : StringConstant
 external interface ResourceConstant : TradableConstant
@@ -479,29 +482,28 @@ external val SIGN_NOVICE_AREA: String
 external val SIGN_RESPAWN_AREA: String
 external val SIGN_PLANNED_AREA: String
 
-// Events should also be some sort of constant
-external val EVENT_ATTACK: Int
-external val EVENT_OBJECT_DESTROYED: Int
-external val EVENT_ATTACK_CONTROLLER: Int
-external val EVENT_BUILD: Int
-external val EVENT_HARVEST: Int
-external val EVENT_HEAL: Int
-external val EVENT_REPAIR: Int
-external val EVENT_RESERVE_CONTROLLER: Int
-external val EVENT_UPGRADE_CONTROLLER: Int
-external val EVENT_EXIT: Int
-external val EVENT_POWER: Int
-external val EVENT_TRANSFER: Int
+external val EVENT_ATTACK: EventConstant<AttackEvent>
+external val EVENT_OBJECT_DESTROYED: EventConstant<DestroyedEvent>
+external val EVENT_ATTACK_CONTROLLER: EventConstant<AttackControllerEvent>
+external val EVENT_BUILD: EventConstant<BuildEvent>
+external val EVENT_HARVEST: EventConstant<HarvestEvent>
+external val EVENT_HEAL: EventConstant<HealEvent>
+external val EVENT_REPAIR: EventConstant<RepairEvent>
+external val EVENT_RESERVE_CONTROLLER: EventConstant<ReserveControllerEvent>
+external val EVENT_UPGRADE_CONTROLLER: EventConstant<UpgradeControllerEvent>
+external val EVENT_EXIT: EventConstant<ExitEvent>
+external val EVENT_POWER: EventConstant<PowerEvent>
+external val EVENT_TRANSFER: EventConstant<TransferEvent>
 
-external val EVENT_ATTACK_TYPE_MELEE: Int
-external val EVENT_ATTACK_TYPE_RANGED: Int
-external val EVENT_ATTACK_TYPE_RANGED_MASS: Int
-external val EVENT_ATTACK_TYPE_DISMANTLE: Int
-external val EVENT_ATTACK_TYPE_HIT_BACK: Int
-external val EVENT_ATTACK_TYPE_NUKE: Int
+external val EVENT_ATTACK_TYPE_MELEE: EventAttackTypeConstant
+external val EVENT_ATTACK_TYPE_RANGED: EventAttackTypeConstant
+external val EVENT_ATTACK_TYPE_RANGED_MASS: EventAttackTypeConstant
+external val EVENT_ATTACK_TYPE_DISMANTLE: EventAttackTypeConstant
+external val EVENT_ATTACK_TYPE_HIT_BACK: EventAttackTypeConstant
+external val EVENT_ATTACK_TYPE_NUKE: EventAttackTypeConstant
 
-external val EVENT_HEAL_TYPE_MELEE: Int
-external val EVENT_HEAL_TYPE_RANGED: Int
+external val EVENT_HEAL_TYPE_MELEE: EventHealTypeConstant
+external val EVENT_HEAL_TYPE_RANGED: EventHealTypeConstant
 
 external interface PowerClassConstant : StringConstant
 

--- a/src/jsMain/kotlin/screeps/api/Events.kt
+++ b/src/jsMain/kotlin/screeps/api/Events.kt
@@ -1,0 +1,73 @@
+package screeps.api
+
+external interface RoomEvent<T : RoomEventData> {
+    val event: EventConstant<T>
+    val objectId: String
+    val data: T
+}
+
+external interface RoomEventData
+
+external interface AttackEvent : RoomEventData {
+    val targetId: String
+    val damage: Int
+    val attackType: EventAttackTypeConstant
+}
+
+external interface DestroyedEvent : RoomEventData {
+    val type: String
+}
+
+external interface AttackControllerEvent : RoomEventData
+
+external interface BuildEvent : RoomEventData {
+    val targetId: String
+    val amount: Int
+    val structureType: BuildableStructureConstant
+    val x: Int
+    val y: Int
+    val incomplete: Any
+}
+
+external interface HarvestEvent : RoomEventData {
+    val targetId: String
+    val amount: Int
+}
+
+external interface HealEvent : RoomEventData {
+    val targetId: String
+    val amount: Int
+    val healType: EventHealTypeConstant
+}
+
+external interface RepairEvent : RoomEventData {
+    val targetId: String
+    val amount: Int
+    val energySpent: Int
+}
+
+external interface ReserveControllerEvent : RoomEventData {
+    val amount: Int
+}
+
+external interface UpgradeControllerEvent : RoomEventData {
+    val amount: Int
+    val energySpent: Int
+}
+
+external interface ExitEvent : RoomEventData {
+    val room: String
+    val x: Int
+    val y: Int
+}
+
+external interface TransferEvent : RoomEventData {
+    val targetId: String
+    val resourceType: ResourceConstant
+    val amount: Int
+}
+
+external interface PowerEvent : RoomEventData {
+    val targetId: String
+    val power: PowerEffectConstant
+}

--- a/src/jsMain/kotlin/screeps/api/Events.kt
+++ b/src/jsMain/kotlin/screeps/api/Events.kt
@@ -1,5 +1,13 @@
 package screeps.api
 
+fun <T : RoomEventData, R> RoomEvent<*>.handle(
+    eventType: EventConstant<T>,
+    handler: (RoomEvent<T>) -> R,
+): R? {
+    if (this.event != eventType) return null
+    return handler.invoke(this.unsafeCast<RoomEvent<T>>())
+}
+
 external interface RoomEvent<T : RoomEventData> {
     val event: EventConstant<T>
     val objectId: String

--- a/src/jsMain/kotlin/screeps/api/Room.kt
+++ b/src/jsMain/kotlin/screeps/api/Room.kt
@@ -38,6 +38,7 @@ abstract external class Room {
     fun lookAt(target: RoomPosition): Array<RoomPosition.Look>
     fun <T> lookForAt(type: LookConstant<T>, x: Int, y: Int): Array<T>?
     fun getTerrain(): Terrain
+    fun getEventLog(): Array<RoomEvent<out RoomEventData>>
 
     class Terrain(roomName: String) {
         val roomName: String
@@ -63,6 +64,9 @@ abstract external class Room {
         fun deserializePath(path: String): Array<PathStep>
     }
 }
+
+fun Room.getEventLogRaw(): String =
+    this.asDynamic().getEventLog(true).unsafeCast<String>()
 
 private typealias LookAtAreaResult = Record<Int, Record<Int, Array<RoomPosition.Look>>>
 


### PR DESCRIPTION
I am not super happy about how this ended up, but opening a PR for discussion and review anyway.

My biggest concern is that an unsafe cast is currently required after getting the type of event.

```
val logs = room.getEventLog()
logs.forEach {
    when (it.event) {
        EVENT_HARVEST -> {
            println("Target id " + it.data.unsafeCast<HarvestEvent>().targetId)
        }
    }
}
```

Would love to do this better somehow